### PR TITLE
Add full wandb train/eval acc metrics, expand rollouts table with more information to Finance Prediction Environment

### DIFF
--- a/environments/fundamental_prediction_environment.py
+++ b/environments/fundamental_prediction_environment.py
@@ -60,7 +60,7 @@ class FundamentalPredictionEnv(BaseEnv):
     def config_init(self) -> Tuple[BaseEnvConfig, List[OpenaiConfig]]:
         env_config = BaseEnvConfig(
             tokenizer_name="NousResearch/DeepHermes-3-Llama-3-8B-Preview",
-            group_size=32,
+            group_size=16,
             use_wandb=True,
             max_num_workers=128,
             rollout_server_url="http://localhost:8000",


### PR DESCRIPTION
This PR adds train/acc for direction & magnitude, eval/acc for direction & magnitude, as well as adds the target metric and ground truth direction and magnitude to the finance prediction environment.

To showcase, this is the rollouts table information prior to my change:
![image](https://github.com/user-attachments/assets/35f7869f-912e-4a41-8b86-2477c9632bdb)

and after:
![image](https://github.com/user-attachments/assets/77321510-0e90-45ed-9a61-0107dd3880ea)
