### PR TITLE
Make run api not reload

### DIFF
--- a/atroposlib/cli/run_api.py
+++ b/atroposlib/cli/run_api.py
@@ -7,7 +7,7 @@ import argparse
 import uvicorn
 
 
-def main(host: str, port: int, reload: bool):
+def main():
     """
     Run the API server.
     Args:
@@ -15,13 +15,15 @@ def main(host: str, port: int, reload: bool):
         port: The port to run the API server on.
         reload: Whether to reload the API server on code changes.
     """
-    uvicorn.run("atroposlib.api:app", host=host, port=port, reload=reload)
-
-
-if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--host", type=str, default="0.0.0.0")
     parser.add_argument("--port", type=int, default=8000)
-    parser.add_argument("--reload", type=bool, default=False)
+    parser.add_argument("--reload", action="store_true")
     args = parser.parse_args()
-    main(args.host, args.port, args.reload)
+    uvicorn.run(
+        "atroposlib.api:app", host=args.host, port=args.port, reload=args.reload
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/atroposlib/cli/run_api.py
+++ b/atroposlib/cli/run_api.py
@@ -1,9 +1,27 @@
+"""
+Run the Trajectory API server.
+"""
+
+import argparse
+
 import uvicorn
 
 
-def main():
-    uvicorn.run("atroposlib.api:app", host="0.0.0.0", port=8000, reload=True)
+def main(host: str, port: int, reload: bool):
+    """
+    Run the API server.
+    Args:
+        host: The host to run the API server on.
+        port: The port to run the API server on.
+        reload: Whether to reload the API server on code changes.
+    """
+    uvicorn.run("atroposlib.api:app", host=host, port=port, reload=reload)
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", type=str, default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--reload", type=bool, default=False)
+    args = parser.parse_args()
+    main(args.host, args.port, args.reload)


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
The current implementation reloads the API when you change code in it's directory. This is frustrating. Added argparse and set the default to not do this, but allow a user to do it if they want to, because freedom of args is a good thing.

<!-- For non-environment PRs -->
### Related Issues
N/A

### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

---

## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions
- [x] If .env vars required, did you add it to the .env.example in repo root?
