### PR TITLE
changed health check to chat completions since all oai models are com…

### DIFF
--- a/atroposlib/envs/server_handling/openai_server.py
+++ b/atroposlib/envs/server_handling/openai_server.py
@@ -29,7 +29,7 @@ class OpenAIServer(APIServer):
             try:
                 await self.openai.chat.completions.create(
                     model=self.config.model_name,
-                    prompt="hi",
+                    messages=[{"role": "user", "content": "hi"}],
                     max_tokens=1,
                 )
                 self.server_healthy = True

--- a/atroposlib/envs/server_handling/openai_server.py
+++ b/atroposlib/envs/server_handling/openai_server.py
@@ -37,8 +37,8 @@ class OpenAIServer(APIServer):
                     await self.openai.completions.create(
                         model=self.config.model_name,
                         prompt="hi",
-                    max_tokens=1,
-                )
+                        max_tokens=1,
+                    )
                 self.server_healthy = True
             except (
                 aiohttp.ClientError,

--- a/atroposlib/envs/server_handling/openai_server.py
+++ b/atroposlib/envs/server_handling/openai_server.py
@@ -24,7 +24,12 @@ class OpenAIServer(APIServer):
         )
         super().__init__(config)
 
-    async def check_server_status_task(self, chat_completion: bool = True):
+    async def check_server_status_task(
+        self, chat_completion: bool = True, skip_check: bool = False
+    ):
+        if skip_check:
+            self.server_healthy = True
+            return
         while True:
             try:
                 if chat_completion:

--- a/atroposlib/envs/server_handling/openai_server.py
+++ b/atroposlib/envs/server_handling/openai_server.py
@@ -24,12 +24,19 @@ class OpenAIServer(APIServer):
         )
         super().__init__(config)
 
-    async def check_server_status_task(self):
+    async def check_server_status_task(self, chat_completion: bool = True):
         while True:
             try:
-                await self.openai.chat.completions.create(
-                    model=self.config.model_name,
-                    messages=[{"role": "user", "content": "hi"}],
+                if chat_completion:
+                    await self.openai.chat.completions.create(
+                        model=self.config.model_name,
+                        messages=[{"role": "user", "content": "hi"}],
+                        max_tokens=1,
+                    )
+                else:
+                    await self.openai.completions.create(
+                        model=self.config.model_name,
+                        prompt="hi",
                     max_tokens=1,
                 )
                 self.server_healthy = True

--- a/atroposlib/envs/server_handling/openai_server.py
+++ b/atroposlib/envs/server_handling/openai_server.py
@@ -24,12 +24,7 @@ class OpenAIServer(APIServer):
         )
         super().__init__(config)
 
-    async def check_server_status_task(
-        self, chat_completion: bool = True, skip_check: bool = False
-    ):
-        if skip_check:
-            self.server_healthy = True
-            return
+    async def check_server_status_task(self, chat_completion: bool = True):
         while True:
             try:
                 if chat_completion:

--- a/atroposlib/envs/server_handling/openai_server.py
+++ b/atroposlib/envs/server_handling/openai_server.py
@@ -27,7 +27,7 @@ class OpenAIServer(APIServer):
     async def check_server_status_task(self):
         while True:
             try:
-                await self.openai.completions.create(
+                await self.openai.chat.completions.create(
                     model=self.config.model_name,
                     prompt="hi",
                     max_tokens=1,

--- a/atroposlib/envs/server_handling/server_baseline.py
+++ b/atroposlib/envs/server_handling/server_baseline.py
@@ -155,9 +155,7 @@ class APIServer(ABC):
         self.eval_sem.update_weight(weight)
 
     @abstractmethod
-    async def check_server_status_task(
-        self, chat_completion: bool = True, skip_check: bool = False
-    ):
+    async def check_server_status_task(self, chat_completion: bool = True):
         """
         Check the status of the server. Should be overridden by the child class.
         Set self.server_healthy to True if the server is healthy.

--- a/atroposlib/envs/server_handling/server_baseline.py
+++ b/atroposlib/envs/server_handling/server_baseline.py
@@ -152,7 +152,7 @@ class APIServer(ABC):
         self.eval_sem.update_weight(weight)
 
     @abstractmethod
-    async def check_server_status_task(self):
+    async def check_server_status_task(self, chat_completion: bool = True):
         """
         Check the status of the server. Should be overridden by the child class.
         Set self.server_healthy to True if the server is healthy.
@@ -320,7 +320,7 @@ class APIServer(ABC):
             if (
                 self.config.base_url is not None
             ):  # skip health check if using OpenAI API
-                self.check_task = asyncio.create_task(self.check_server_status_task())
+                self.check_task = asyncio.create_task(self.check_server_status_task(chat_completion=False))
             else:
                 self.server_healthy = True
             self.initialized = True

--- a/atroposlib/envs/server_handling/server_baseline.py
+++ b/atroposlib/envs/server_handling/server_baseline.py
@@ -123,6 +123,9 @@ class APIServerConfig(ServerBaseline):
     n_kwarg_is_ignored: bool = Field(
         default=False, description="Whether the n kwarg is ignored by this API server."
     )
+    health_check: bool = Field(
+        default=True, description="Whether to perform a health check on the server."
+    )
 
 
 class APIServer(ABC):
@@ -152,7 +155,9 @@ class APIServer(ABC):
         self.eval_sem.update_weight(weight)
 
     @abstractmethod
-    async def check_server_status_task(self, chat_completion: bool = True):
+    async def check_server_status_task(
+        self, chat_completion: bool = True, skip_check: bool = False
+    ):
         """
         Check the status of the server. Should be overridden by the child class.
         Set self.server_healthy to True if the server is healthy.
@@ -256,10 +261,15 @@ class APIServer(ABC):
         Chat completion handler, waits for the server to be healthy and then calls the chat completion wrapper.
         """
         if not self.initialized:
-            if (
-                self.config.base_url is not None
-            ):  # skip health check if using OpenAI API
-                self.check_task = asyncio.create_task(self.check_server_status_task())
+            if self.config.health_check:
+                if (
+                    self.config.base_url is not None
+                ):  # skip health check if using OpenAI API
+                    self.check_task = asyncio.create_task(
+                        self.check_server_status_task()
+                    )
+                else:
+                    self.server_healthy = True
             else:
                 self.server_healthy = True
             self.initialized = True
@@ -317,13 +327,17 @@ class APIServer(ABC):
         Completion handler, waits for the server to be healthy and then calls the completion wrapper.
         """
         if not self.initialized:
-            if (
-                self.config.base_url is not None
-            ):  # skip health check if using OpenAI API
-                self.check_task = asyncio.create_task(
-                    self.check_server_status_task(chat_completion=False)
-                )
+            if self.config.health_check:
+                if (
+                    self.config.base_url is not None
+                ):  # skip health check if using OpenAI API
+                    self.check_task = asyncio.create_task(
+                        self.check_server_status_task(chat_completion=False)
+                    )
+                else:
+                    self.server_healthy = True
             else:
+                # If health_check is False, always assume healthy
                 self.server_healthy = True
             self.initialized = True
         kwargs["model"] = self.config.model_name

--- a/atroposlib/envs/server_handling/server_baseline.py
+++ b/atroposlib/envs/server_handling/server_baseline.py
@@ -320,7 +320,9 @@ class APIServer(ABC):
             if (
                 self.config.base_url is not None
             ):  # skip health check if using OpenAI API
-                self.check_task = asyncio.create_task(self.check_server_status_task(chat_completion=False))
+                self.check_task = asyncio.create_task(
+                    self.check_server_status_task(chat_completion=False)
+                )
             else:
                 self.server_healthy = True
             self.initialized = True

--- a/atroposlib/envs/server_handling/trl_vllm_server.py
+++ b/atroposlib/envs/server_handling/trl_vllm_server.py
@@ -28,9 +28,7 @@ class TrlVllmServer(APIServer):
         self.tokenizer = AutoTokenizer.from_pretrained(config.model_name)
         super().__init__(config)
 
-    async def check_server_status_task(
-        self, chat_completion: bool = True, skip_check: bool = False
-    ):
+    async def check_server_status_task(self, chat_completion: bool = True):
         """
         TODO: Implement server health check for trl's vLLM server
         """

--- a/atroposlib/envs/server_handling/trl_vllm_server.py
+++ b/atroposlib/envs/server_handling/trl_vllm_server.py
@@ -6,7 +6,6 @@ Developed with much help from @winglian when they worked on integrating Atropos 
 
 import time
 import uuid
-import asyncio
 
 import aiohttp
 from openai.types.chat.chat_completion import (
@@ -29,39 +28,11 @@ class TrlVllmServer(APIServer):
         self.tokenizer = AutoTokenizer.from_pretrained(config.model_name)
         super().__init__(config)
 
-    async def check_server_status_task(self, _ = True):
+    async def check_server_status_task(self, chat_completion: bool = True):
         """
-        Perform a health check for the TRL VLLM server by sending a minimal request to /generate.
+        TODO: Implement server health check for trl's vLLM server
         """
-        health_check_url = f"{self.config.base_url}/generate/"
-        # Minimal payload that the /generate endpoint would accept without erroring.
-        # This might need adjustment based on the TRL VLLM server's specific requirements.
-        minimal_payload = {
-            "prompts": ["test"], # Using a non-empty prompt as some servers might require it
-            "max_tokens": 1,
-            "n": 1
-        }
-        while True:
-            try:
-                async with aiohttp.ClientSession() as session:
-                    async with session.post(health_check_url, json=minimal_payload, timeout=10) as response: # Added timeout
-                        if response.status == 200:
-                            # Optionally, further check response content if a specific "healthy" body is expected
-                            # For now, status 200 is considered healthy.
-                            self.server_healthy = True
-                        else:
-                            # Log warning for non-200 status if a logger is available/configured
-                            # logger.warning(f"TRL VLLM server health check failed: Status {response.status} for {health_check_url}")
-                            self.server_healthy = False
-            except aiohttp.ClientError as e:
-                # Log error for connection issues if a logger is available/configured
-                # logger.error(f"TRL VLLM server health check connection error: {e}")
-                self.server_healthy = False
-            except Exception as e: # Catch any other unexpected errors during the check
-                # Log error for unexpected issues if a logger is available/configured
-                # logger.error(f"Unexpected error during TRL VLLM server health check: {e}")
-                self.server_healthy = False
-            await asyncio.sleep(10) # Check periodically (e.g., every 10 seconds)
+        self.server_healthy = True
 
     async def _chat_completion_wrapper(self, **kwargs) -> ChatCompletion:
         """

--- a/atroposlib/envs/server_handling/trl_vllm_server.py
+++ b/atroposlib/envs/server_handling/trl_vllm_server.py
@@ -28,7 +28,9 @@ class TrlVllmServer(APIServer):
         self.tokenizer = AutoTokenizer.from_pretrained(config.model_name)
         super().__init__(config)
 
-    async def check_server_status_task(self, chat_completion: bool = True):
+    async def check_server_status_task(
+        self, chat_completion: bool = True, skip_check: bool = False
+    ):
         """
         TODO: Implement server health check for trl's vLLM server
         """


### PR DESCRIPTION
…patible with that, and it should work with compatible servers

<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
│  Select PR type below and fill applicable sections.       │
│  Delete non-applicable sections for your PR type.         │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
<!-- Please check ONE of the following options -->
- [ ] RL Environment PR - Complete Environment Snapshot & Zero-Training sections
- [X] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
<!-- Briefly describe the changes or additions introduced by this pull request. -->

<!-- For non-environment PRs -->
### Related Issues
[<!-- Link any relevant issues here. Use "Closes #issue_number" to automatically close issues. -->](https://github.com/NousResearch/atropos/issues/55)

### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code refactor (no functional changes)
- [ ] Build/CI/CD related changes
- [ ] Other (please describe):

## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [X] Code follows project style (black, isort, flake8 pass with pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Docstrings added for all new public classes / functions
- [X] If .env vars required, did you add it to the .env.example in repo root?
