### PR TITLE
[draft] gsm8k with multi-thought format (jules)

### DIFF
--- a/environments/gsm8k_server.py
+++ b/environments/gsm8k_server.py
@@ -1,4 +1,5 @@
 import random
+import re # Added import
 from typing import Dict, List, Optional, Tuple, TypedDict, Union
 
 from datasets import load_dataset
@@ -16,19 +17,50 @@ from atroposlib.type_definitions import Item, number
 from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
 
 system_prompt = (
-    "You are a deep thinking AI, you may use extremely long chains of thought "
-    "to deeply consider the problem and deliberate with yourself via systematic "
-    "reasoning processes to help come to a correct solution prior to answering. "
-    "You should enclose your thoughts and internal monologue inside <think> </think> "
-    "tags, and then provide your solution or response to the problem.\n\n"
+    "You are a deep thinking AI. To solve the problem, you must use a multi-thought process. "
+    "Enclose your thoughts in <think> tags, with each thought in its own tag like so: "
+    "<think><thought_1>first thought</thought_1><thought_2>second thought</thought_2>"
+    "...<thought_n>nth thought</thought_n></think>"
+    "After your thoughts, provide your answer to the problem.\n\n"
 )
 
 system_prompt += """You are allocated a maximum of 2048 tokens, please strive to use less.
 
-You will then provide your answer like this: \\boxed{your answer here}
+Your final answer must end with \\boxed{your answer here}.
 It is important that you provide your answer in the correct format.
 If you do not, you will not receive credit for your answer.
 So please end your answer with \\boxed{your answer here}"""
+
+
+def extract_final_answer_segment(completion_text: str) -> str:
+    """
+    Extracts the segment of the completion text that likely contains the final answer.
+    This is typically the portion after the last </think> tag.
+    """
+    last_think_tag_index = completion_text.rfind("</think>")
+    if last_think_tag_index != -1:
+        return completion_text[last_think_tag_index + len("</think>"):]
+    return completion_text # Fallback to the whole string if </think> is not found
+
+
+def check_multi_thought_format(completion_text: str) -> bool:
+    """
+    Checks if the completion text follows the multi-thought format.
+    Format: <think><thought_1>...</thought_1><thought_2>...</thought_2>...</think>
+    """
+    think_match = re.search(r"<think>(.*)</think>", completion_text, re.DOTALL)
+    if not think_match:
+        return False
+    
+    thinking_block = think_match.group(1)
+    
+    # Check for at least one well-formed <thought_N>...</thought_N> tag within the <think> block
+    # This ensures there's at least one thought, and it's properly closed.
+    # Using a non-greedy match for the content of thought_N to handle multiple such tags correctly.
+    if re.search(r"<thought_\d+>.*?</thought_\d+>", thinking_block, re.DOTALL):
+        return True
+        
+    return False
 
 
 class GSM8kRow(TypedDict):
@@ -121,11 +153,9 @@ class GSM8kEnv(BaseEnv):
         super().save_checkpoint(step, data)
 
     async def rollout_and_score_eval(self, question: str, answer: str) -> number:
-        completion = await self.server.chat_completion(
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": question},
-            ],
+        prompt = system_prompt + "\n\nUser: " + question + "\nAssistant: "
+        completion = await self.server.completion(
+            prompt=prompt,
             n=1,
             max_tokens=self.config.max_token_length,
             temperature=0.0,
@@ -136,8 +166,9 @@ class GSM8kEnv(BaseEnv):
             extraction_mode="first_match",
             extraction_config=[LatexExtractionConfig()],
         )
+        answer_segment = extract_final_answer_segment(completion.choices[0].text)
         answer_parsed = parse(
-            completion.choices[0].message.content.split("</think>")[-1],
+            answer_segment,
             extraction_config=[
                 LatexExtractionConfig(
                     normalization_config=NormalizationConfig(
@@ -170,29 +201,35 @@ class GSM8kEnv(BaseEnv):
     async def collect_trajectories(
         self, item: GSM8kRow
     ) -> Tuple[ScoredDataGroup, list[Item]]:
-        user_message = {"role": "user", "content": item["question"]}
+        prompt = system_prompt + "\n\nUser: " + item["question"] + "\nAssistant: "
         gold_answer = (
             "\\boxed{" + item["answer"].split("#")[-1].strip().replace(",", "") + "}"
         )
 
-        chat_completions = await self.server.chat_completion(
-            messages=[{"role": "system", "content": system_prompt}, user_message],
+        completions = await self.server.completion(
+            prompt=prompt,
             n=self.config.group_size,
             max_tokens=self.config.max_token_length,
         )
         to_score = list()
         to_backlog = list()
-        for i, chat_completion in enumerate(chat_completions.choices):
-            messages = (
-                {"role": "system", "content": system_prompt},
-                user_message,
-                {"role": "assistant", "content": chat_completion.message.content},
-            )
+        for i, completion_choice in enumerate(completions.choices):
+            # Construct messages for tokenize_for_trainer
+            # The system prompt is implicitly part of the prompt passed to the completion endpoint
+            # For tokenization, we'll represent the interaction as:
+            # 1. User's question (which was part of the input prompt)
+            # 2. Assistant's full response (text from completion)
+            messages = [
+                {"role": "user", "content": item["question"]}, # Original question for context
+                {"role": "assistant", "content": completion_choice.text},
+            ]
             to_score.append(
                 {
-                    "messages": messages,
+                    "messages": messages, # This will be used by tokenize_for_trainer
+                    "raw_prompt": prompt, # Keep the full prompt for potential future use/debugging
+                    "raw_completion": completion_choice.text, # Keep raw completion
                     "gold_answer": gold_answer,
-                    "finish_reason": chat_completion.finish_reason,
+                    "finish_reason": completion_choice.finish_reason,
                 }
             )
         to_postprocess = await self.score(to_score)
@@ -205,6 +242,8 @@ class GSM8kEnv(BaseEnv):
         scores["tokens"] = list()
         scores["masks"] = list()
         scores["scores"] = list()
+        scores["messages"] = list() # Initialize messages list
+        final_correctness_scores = [] # Stores base correctness (1.0/-1.0) for non-skipped items
         gold_parsed = parse(
             rollout_group_data[0]["gold_answer"],
             extraction_mode="first_match",
@@ -213,10 +252,11 @@ class GSM8kEnv(BaseEnv):
         if len(gold_parsed) != 0:
             # We require the answer to be provided in correct latex (no malformed operators)
             random.shuffle(rollout_group_data)
-            for item in rollout_group_data:
+            for data_item in rollout_group_data: # Renamed item to avoid conflict
                 # print(item[0][-1]["content"])
+                answer_segment = extract_final_answer_segment(data_item["raw_completion"])
                 answer_parsed = parse(
-                    item["messages"][-1]["content"].split("</think>")[-1],
+                    answer_segment, # Use extracted segment
                     extraction_config=[
                         LatexExtractionConfig(
                             normalization_config=NormalizationConfig(
@@ -235,28 +275,69 @@ class GSM8kEnv(BaseEnv):
                     extraction_mode="first_match",
                 )
                 # Reward 1 if the content is the same as the ground truth, 0 otherwise
-                reward = verify(answer_parsed, gold_parsed)
+                correctness_verified = verify(answer_parsed, gold_parsed)
                 # print(
-                #     f"message: {item[0][-1]['content']}, ground_truth: {item[1]}, reward: {reward}"
+                #     f"message: {data_item['raw_completion']}, ground_truth: {data_item['gold_answer']}, reward: {correctness_verified}"
                 # )
-                out_dict = tokenize_for_trainer(
-                    self.tokenizer, item["messages"], item["finish_reason"]
-                )
-                tokens = out_dict["tokens"]
-                masks = out_dict["masks"]
-                # remove obviously bad examples
-                if len([1 for i in masks if i != -100]) < 10:
+                
+                base_score = 1.0 if correctness_verified else -1.0
+                
+                # Manual tokenization and masking
+                full_text = data_item["raw_prompt"] + data_item["raw_completion"]
+                tokens = self.tokenizer.encode(full_text)
+                
+                prompt_tokens = self.tokenizer.encode(data_item["raw_prompt"])
+                if prompt_tokens and prompt_tokens[-1] == self.tokenizer.eos_token_id:
+                    prompt_tokens = prompt_tokens[:-1]
+                
+                # Basic assertion to ensure prompt tokens are a prefix of full tokens
+                # This might need adjustment if the tokenizer adds special tokens differently
+                # to concatenated strings vs. individual strings.
+                # A more robust check might involve re-encoding raw_completion and comparing.
+                assert tokens[:len(prompt_tokens)] == self.tokenizer.encode(data_item["raw_prompt"])[:len(prompt_tokens)], \
+                       "Token mismatch between prompt and start of full text"
+
+                masks = [-100] * len(prompt_tokens) + tokens[len(prompt_tokens):]
+
+                # Construct messages for logging (similar to math_server_zero.py)
+                log_messages = [
+                    {"role": "user", "content": data_item["raw_prompt"]}, 
+                    {"role": "assistant", "content": data_item["raw_completion"]}
+                ]
+                scores["messages"].append(log_messages)
+
+                # remove obviously bad examples (completion too short)
+                if sum(1 for m_val in masks if m_val != -100) < 10:
+                    # Need to pop the message if we skip, or handle this before appending message
+                    scores["messages"].pop() # Remove the last added message
                     continue
+                
+                # If not skipped:
+                final_correctness_scores.append(base_score)
+
+                # Apply format reward/penalty to get the final score for training
+                format_bonus = 0.1 
+                format_is_good = check_multi_thought_format(data_item["raw_completion"])
+                final_score_for_training = base_score + (format_bonus if format_is_good else -format_bonus)
+                
                 scores["tokens"].append(tokens)
                 scores["masks"].append(masks)
-                scores["scores"].append(1.0 if reward else -1.0)
-                if len(scores["tokens"]) >= self.config.group_size:
+                scores["scores"].append(final_score_for_training)
+
+                if len(scores["tokens"]) >= self.config.group_size: # or final_correctness_scores
                     break
-            for score in scores["scores"]:
-                self.percent_correct_buffer.append(max(score, 0))
-            # check if all the same
-            # print(scores['scores'])
-            if all([score == 1 for score in scores["scores"]]):
+            
+            if not final_correctness_scores: # If all items were skipped
+                return None
+
+            # Update percent_correct_buffer with actual correctness scores
+            for c_score in final_correctness_scores:
+                self.percent_correct_buffer.append(max(c_score, 0.0))
+            
+            # Length penalty check using final_correctness_scores
+            # print(scores['scores']) # This would print training scores
+            # print(final_correctness_scores) # This would print base scores
+            if final_correctness_scores and all([c_score == 1.0 for c_score in final_correctness_scores]):
                 # Do length penalty :)
                 token_lengths = [len(token) for token in scores["tokens"]]
                 if max(token_lengths) == 0:


### PR DESCRIPTION
Here are the changes I made to gsm8k_server.py:
- It now uses a completions API endpoint instead of chat completions.
- I've implemented a new thinking format: `<think><thought_1>...</thought_1>...</think>answer`.
- The system prompt has been updated to reflect the new format.
- Answer extraction in scoring has been modified to work with the new format.
- Tokenization and masking have been adapted to align with completions API usage (similar to math_server_zero.py).
- I've added a format reward (+/- 0.1) to encourage the new thinking structure.
- Reward application has been refined to ensure compatibility with existing length penalty and 'all scores same' data filtering logic.

<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
│  Select PR type below and fill applicable sections.       │
│  Delete non-applicable sections for your PR type.         │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
<!-- Please check ONE of the following options -->
- [ ] RL Environment PR - Complete Environment Snapshot & Zero-Training sections
- [ ] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
<!-- Briefly describe the changes or additions introduced by this pull request. -->

<!-- For non-environment PRs -->
### Related Issues
<!-- Link any relevant issues here. Use "Closes #issue_number" to automatically close issues. -->

### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code refactor (no functional changes)
- [ ] Build/CI/CD related changes
- [ ] Other (please describe):

---

## 🔖 Environment Snapshot
<!-- For RL Environment PRs only -->
| Field | Your Entry |
|-------|------------|
| **Environment Name** | <!-- e.g. "SudokuVerifier-v0" --> |
| **Short Description** | <!-- One-sentence purpose/goal. --> |
| **Category** | <!-- Select: Verifiable-Reasoning / RLAIF / RLHF / Other  --> |
| **Dataset Needed?** | <!-- No / Yes (link & license) --> |
| **External Deps** | <!-- Extra pip packages, system libs, etc. --> |
| **Environmental Variables** | <!-- variable name(s) --> |
| **Compute Footprint Estimate** | <!-- "<1 GB RAM, <1 min CPU verification" or similar --> |

## 🧪 Zero-Training Test Results
<!-- For RL Environment PRs only -->
<details>

**W&B Link:**

**Examples of the Environment scoring a good example and a bad example:**

</details>

---

## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [ ] Code follows project style (black, isort, flake8 pass with pre-commit)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Docstrings added for all new public classes / functions
- [ ] If .env vars required, did you add it to the .env.example in repo root?
