### PR TITLE
Structured Outputs RL Environment

### DIFF
--- a/environments/structured_outputs_server.py
+++ b/environments/structured_outputs_server.py
@@ -1,0 +1,315 @@
+import ast
+import json
+import random
+import re
+from typing import Dict, List, Optional, Tuple, Union
+
+import wandb
+from datasets import load_dataset
+from tqdm.asyncio import tqdm_asyncio
+
+from atroposlib.envs.base import (
+    APIServerConfig,
+    BaseEnv,
+    BaseEnvConfig,
+    EvalHandlingEnum,
+    Item,
+    ScoredDataGroup,
+)
+from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
+
+from jsonschema import validate as json_validate, ValidationError
+
+system_prompt = (
+    "You are a deep thinking AI, you may use extremely long chains of thought to deeply consider the "
+    "problem and deliberate with yourself via systematic reasoning processes to help come to a correct "
+    "solution prior to answering. You should enclose your thoughts and internal monologue inside <think> "
+    "</think> tags, and then provide your solution or response to the problem."
+)
+
+def _extract_json(text: str) -> Optional[dict]:
+    """
+    Extract the *first* JSON object that appears immediately after the model’s
+    internal <think> … </think> block.
+
+    • Any non‑whitespace characters between </think> and the opening “{” cause
+      the extraction to fail (we want the model to output pure JSON).
+
+    • Uses json.JSONDecoder.raw_decode for robust brace matching instead of a
+      greedy regex.
+    """
+    # Keep only the area after the *last* </think>
+    after_think = text.split("</think>")[-1]
+
+    # Allow leading whitespace/newlines but *nothing else*
+    stripped_leading = after_think.lstrip()
+    leading_before_json = after_think[: len(after_think) - len(stripped_leading)]
+    if stripped_leading.startswith("{") is False:
+        # Either we have non‑whitespace chatter or no JSON at all
+        return None
+    if any(c not in " \t\r\n" for c in leading_before_json):
+        # Non‑whitespace junk before the JSON
+        return None
+
+    decoder = json.JSONDecoder()
+    try:
+        obj, _ = decoder.raw_decode(stripped_leading)
+        return obj
+    except json.JSONDecodeError:
+        return None
+
+def _subset_match(candidate: dict, reference: dict) -> bool:
+    for k, v in reference.items():
+        if k not in candidate or candidate[k] != v:
+            return False
+    return True
+
+def _ensure_schema_dict(schema_raw) -> Optional[dict]:
+    if schema_raw is None:
+        return None
+    return json.loads(schema_raw)
+
+
+class StructuredOutputsEnv(BaseEnv):
+    name = "json_struct"
+
+    def __init__(
+        self,
+        config: BaseEnvConfig,
+        server_configs: List[APIServerConfig],
+        slurm: bool = True,
+        testing: bool = False,
+    ):
+        super().__init__(config, server_configs, slurm, testing)
+        self.percent_correct_buffer = []
+        self.eval_metrics = []
+        # Rollout visualisation
+        self.rollouts_for_wandb =[]
+        self.completion_lengths = []
+
+    @classmethod
+    def config_init(self) -> Tuple[BaseEnvConfig, List[APIServerConfig]]:
+        env_cfg = BaseEnvConfig(
+            tokenizer_name="NousResearch/DeepHermes-3-Llama-3-8B-Preview",
+            group_size=16,
+            use_wandb=True,
+            rollout_server_url="http://localhost:8000",
+            total_steps=2000,
+            batch_size=1024,
+            steps_per_eval=20,
+            max_token_length=16 * 1024,
+            inference_weight=1.0,
+            wandb_name="json_struct",
+            eval_handling=EvalHandlingEnum.LIMIT_TRAIN,
+            eval_limit_ratio=0.1,
+        )
+        srv_cfgs = [
+            APIServerConfig(
+                model_name="NousResearch/DeepHermes-3-Llama-3-8B-Preview",
+                base_url="http://localhost:9004/v1",
+                api_key="x",
+                num_max_requests_at_once=32,
+                num_requests_for_eval=256,
+            )
+        ]
+        return env_cfg, srv_cfgs
+
+    async def setup(self):
+        ds = load_dataset("interstellarninja/json-mode-agentic", split="train").shuffle(
+            seed=42
+        )
+        split = ds.train_test_split(0.02, seed=42)
+        self.train, self.test = split["train"], split["test"]
+        self.iter = 0
+
+        self.percent_correct_buffer: List[float] = []
+        self.eval_metrics: List[Tuple[str, float]] = []
+
+    def _score(self, cand_txt: str, gold_txt: str, schema: Optional[dict]) -> int:
+        # Assumes schema is either dict or None
+        cand = _extract_json(cand_txt)
+        gold = _extract_json(gold_txt)
+        if cand is None or gold is None:
+            return 0
+        if schema:
+            try:
+                json_validate(cand, schema)
+            except ValidationError:
+                return 0
+        return 1 if _subset_match(cand, gold) else 0
+
+    async def rollout_and_score_eval(self, item) -> int:
+        conv = item["conversations"]
+        sys = next((m for m in conv if m["from"] == "system"), None)
+        usr = next((m for m in conv if m["from"] == "human"), None)
+        gold = next((m for m in conv if m["from"] == "gpt"), None)
+        if not usr or not gold:
+            return 0
+        schema = _ensure_schema_dict(item["schema"])
+        msgs = [
+            {
+                "role": "system",
+                "content": system_prompt + "\n\n" + (sys["value"] if sys else ""),
+            },
+            {"role": "user", "content": usr["value"]},
+        ]
+        prompt = self.tokenizer.apply_chat_template(
+            msgs, add_generation_prompt=True, tokenize=False
+        )
+        comp = await self.server.completion(
+            prompt=prompt,
+            n=1,
+            max_tokens=self.config.max_token_length - len(prompt),
+            temperature=0.0,
+            split="eval",
+        )
+        return self._score(comp.choices[0].text, gold["value"], schema)
+
+    async def evaluate(self, *_, **__):
+        scs = await tqdm_asyncio.gather(
+            *[self.rollout_and_score_eval(t) for t in self.test]
+        )
+        self.eval_metrics.append(("eval/percent_correct", sum(scs) / len(scs)))
+
+    async def get_next_item(self):
+        row = self.train[self.iter % len(self.train)]
+        self.iter += 1
+        conv = row["conversations"]
+        sys = next((m for m in conv if m["from"] == "system"), None)
+        usr = next((m for m in conv if m["from"] == "human"), None)
+        gold = next((m for m in conv if m["from"] == "gpt"), None)
+
+        prompt = []
+        if sys:
+            prompt.append(
+                frozenset(
+                    {
+                        "role": "system",
+                        "content": system_prompt + "\n\n" + sys["value"],
+                    }.items()
+                )
+            )
+        prompt.append(frozenset({"role": "user", "content": usr["value"]}.items()))
+        answer = gold["value"] if gold else ""
+        schema = _ensure_schema_dict(row["schema"])
+        return (tuple(prompt), answer, schema)
+
+    async def collect_trajectories(
+        self, itm
+    ) -> Tuple[ScoredDataGroup, List[Item]]:
+        msgs = [dict(p) for p in itm[0]]
+        schema = itm[2]
+        prompt = self.tokenizer.apply_chat_template(
+            msgs, add_generation_prompt=True, tokenize=False
+        )
+        comps = await self.server.completion(
+            prompt=prompt,
+            n=self.config.group_size,
+            max_tokens=self.config.max_token_length - len(prompt),
+            temperature=0.8,
+        )
+        bunch = []
+        for ch in comps.choices:
+            bunch.append(
+                (
+                    msgs + [{"role": "assistant", "content": ch.text}],
+                    itm[1],
+                    schema,
+                    ch.finish_reason,
+                )
+            )
+
+        scored = await self.score(bunch)
+        if scored is not None:
+            await self.add_rollouts_for_wandb(scored, itm)
+        return scored, []
+
+    async def score(self, data) -> Optional[ScoredDataGroup]:
+        sd = ScoredDataGroup(tokens=[], masks=[], scores=[])
+        random.shuffle(data)
+        for msgs, gold, schema, fin in data:
+            reward = self._score(msgs[-1]["content"], gold, schema)
+            out = tokenize_for_trainer(
+                tokenizer=self.tokenizer,
+                chat=msgs,
+                finish_reason=fin,
+                include_messages=True,
+            )
+            if len([m for m in out["masks"] if m != -100]) < 10:
+                continue
+            sd["tokens"].append(out["tokens"])
+            sd["masks"].append(out["masks"])
+            sd["scores"].append(1.0 if reward else -1.0)
+            if len(sd["tokens"]) >= self.config.group_size:
+                break
+        # Apply length penalty if all responses are initially correct
+        if sd["scores"] and all(score == 1.0 for score in sd["scores"]):
+            token_lengths = [len(toks) for toks in sd["tokens"]]
+            max_allowed_length = self.config.max_token_length
+            length_threshold = max_allowed_length * 0.5 
+            sd["scores"] = []
+            for length in token_lengths:
+                if length <= length_threshold:
+                    sd["scores"].append(1.0)
+                else:
+                    pct = (length - length_threshold) / (max_allowed_length - length_threshold)
+                    pct = min(pct, 1.0)
+                    sd["scores"].append(1.0 - pct)
+        self.percent_correct_buffer.extend(max(0, s) for s in sd["scores"])
+        if len(sd["tokens"]) < self.config.group_size:
+            return None
+        if all(s == sd["scores"][0] for s in sd["scores"]):
+            return None
+        return sd
+
+
+    async def create_rollout_table(self, wandb_metrics: Dict):
+        if self.rollouts_for_wandb:
+            table = wandb.Table(columns=["generation", "score", "expected_json"])
+            for group in self.rollouts_for_wandb:
+                for gen, score, expected in group:
+                    table.add_data(gen, score, expected)
+            wandb_metrics["train/rollouts"] = table
+
+        self.rollouts_for_wandb = []
+        return wandb_metrics
+
+    async def add_rollouts_for_wandb(
+        self,
+        scored_data: ScoredDataGroup,
+        item: Item,
+    ):
+        num_keep = getattr(self.config, "num_rollouts_per_group_for_logging", -1)
+        if num_keep == -1:
+            num_keep = self.config.group_size
+        self.rollouts_for_wandb.append(
+            [
+                (
+                    self.tokenizer.decode(scored_data["tokens"][i]),
+                    scored_data["scores"][i],
+                    item[1],  # expected JSON string
+                )
+                for i in range(num_keep)
+            ]
+        )
+        if len(self.rollouts_for_wandb) > getattr(
+            self.config, "num_rollouts_to_keep", 4
+        ):
+            self.rollouts_for_wandb.pop(0)
+
+    async def wandb_log(self, metrics: Optional[Dict] = None):
+        metrics = metrics or {}
+        metrics = await self.create_rollout_table(metrics)
+        if self.percent_correct_buffer:
+            metrics["train/percent_correct"] = sum(self.percent_correct_buffer) / len(
+                self.percent_correct_buffer
+            )
+            self.percent_correct_buffer.clear()
+        for k, v in self.eval_metrics:
+            metrics[k] = v
+        self.eval_metrics.clear()
+        await super().wandb_log(metrics)
+
+
+if __name__ == "__main__":
+    StructuredOutputsEnv.cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@ requests>=2.28.0
 python-dotenv>=0.19.0
 gymnasium>=0.28.1
 numpy>=1.24.0
+jsonschema>=4.24.0
 # Atropos would be included here in a full implementation
 # atropos>=0.1.0


### PR DESCRIPTION
## PR Type
- [x] RL Environment PR - Complete Environment Snapshot & Zero-Training sections

---

## 🔖 Environment Snapshot
| Field | Your Entry |
|-------|------------|
| **Environment Name** | `StructuredOutputsEnv` |
| **Short Description** | Trains model to generate structured JSON outputs conforming to a predefined schema. |
| **Category** | Dataset environments |
| **Dataset Needed?** | Yes (interstellarninja/json-mode-agentic, Apache 2.0 License) |
| **External Deps** | `jsonschema` |
| **Environmental Variables** | None |
| **Compute Footprint Estimate** | <1 GB RAM, <5 min CPU verification |

## 🧪 Zero-Training Test Results
<details>

**W&B Link:**
https://wandb.ai/paranoidandroid/atropos-environments/runs/cuxlj79o?nw=nwuserinterstellarninja

**Examples of the Environment scoring a good example and a bad example:**
Good Example:
<|begin_of_text|><|start_header_id|>system<|end_header_id|>

You are a deep thinking AI, you may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes to help come to a correct solution prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem.

You are a helpful assistant that answers in JSON. Here's the json schema you must adhere to:
<schema>
{'description': 'An address similar to http://microformats.org/wiki/h-card', 'type': 'object', 'properties': {'postOfficeBox': {'type':'string'}, 'extendedAddress': {'type':'string'},'streetAddress': {'type':'string'}, 'locality': {'type':'string'},'region': {'type':'string'}, 'postalCode': {'type':'string'}, 'countryName': {'type':'string'}},'required': ['locality','region', 'countryName'], 'dependentRequired': {'postOfficeBox': ['streetAddress'], 'extendedAddress': ['streetAddress']}}
</schema><|eot_id|><|start_header_id|>user<|end_header_id|>

Please generate a JSON output for an address schema that includes a post office box, street address, locality, region, postal code, and country name. Ensure that the locality, region, and country name are mandatory fields. If a post office box or an extended address is provided, a street address must be included as well. For instance, the address is: Post Office Box 1122, Apartment 31, 123 Maple Street, Lakeside, Minnesota, 55014, USA. The post office box should be listed as 'PO Box 1122', the extended address should be noted as 'Apartment 31', and the street address should be '123 Maple Street'. The locality is 'Lakeside', which is a mandatory field, as is the region 'Minnesota', and the country name 'USA'. The postal code for this address is '55014'. All these details are crucial to ensure the JSON object accurately represents the physical location in a structured format.<|eot_id|><|start_header_id|>assistant<|end_header_id|>

<think>
Okay, let's tackle this problem. The user wants a JSON object based on the given address schema. Let me start by recalling the schema details. The schema requires the JSON object to have certain properties. The mandatory fields are locality, region, and countryName. Additionally, if there's a postOfficeBox or extendedAddress provided, then the streetAddress must also be included. 

Looking at the example address: "Post Office Box 1122, Apartment 31, 123 Maple Street, Lakeside, Minnesota, 55014, USA." I need to map each part of this address to the schema properties. 

First, the postOfficeBox is mentioned as 'PO Box 1122'. The example uses "Post Office Box 1122", so the key here is to format it as per the schema, which refers to it as 'postOfficeBox' and wants it as 'PO Box 1122'. The extendedAddress is 'Apartment 31', and the streetAddress is '123 Maple Street'. 

The locality is 'Lakeside', region is 'Minnesota', and countryName is 'USA', which are all required. The postal code is '55014'. 

Now, according to the dependentRequired rules, since there's a postOfficeBox (PO Box 1122) and an extendedAddress (Apartment 31), the streetAddress must be present. The example already has a streetAddress, so that's covered. 

I need to construct the JSON object with these fields. Let's list them out:

postOfficeBox: "PO Box 1122"
extendedAddress: "Apartment 31"
streetAddress: "123 Maple Street"
locality: "Lakeside"
region: "Minnesota"
postalCode: "55014"
countryName: "USA"

Wait, the postalCode is part of the schema, but in the example, the postal code is '55014'. However, the problem statement mentions to include postal code. So I need to add the postalCode as '55014'. 

Double-checking the schema: the required fields are locality, region, countryName. The other fields are optional unless dependent on others. Since postOfficeBox and extendedAddress are present, streetAddress is required, which is already there. 

So putting it all together, the JSON should look like:

{
  "postOfficeBox": "PO Box 1122",
  "extendedAddress": "Apartment 31",
  "streetAddress": "123 Maple Street",
  "locality": "Lakeside",
  "region": "Minnesota",
  "postalCode": "55014",
  "countryName": "USA"
}

Wait, but the schema includes 'postalCode' as a property, so that's included. Also, the original example lists the postal code as '55014', so that's correct. 

Wait, but in the example address, the postal code is given as 55014. So yes, that's included. So the JSON should have all those fields. 

I think that's all. Let me verify once more. The dependentRequired says that if postOfficeBox is present, then streetAddress must be there. Here, postOfficeBox is present, and streetAddress is present. Similarly, extendedAddress is present, streetAddress is present. All required fields are included. So that's correct.
</think>

{ 
  "postOfficeBox": "PO Box 1122", 
  "extendedAddress": "Apartment 31", 
  "streetAddress": "123 Maple Street", 
  "locality": "Lakeside", 
  "region": "Minnesota", 
  "postalCode": "55014", 
  "countryName": "USA" 
}<|eot_id|>

Bad Example:
<|begin_of_text|><|start_header_id|>system<|end_header_id|>

You are a deep thinking AI, you may use extremely long chains of thought to deeply consider the problem and deliberate with yourself via systematic reasoning processes to help come to a correct solution prior to answering. You should enclose your thoughts and internal monologue inside <think> </think> tags, and then provide your solution or response to the problem.

You are a helpful assistant that answers in JSON. Here's the json schema you must adhere to:
<schema>
{'title': 'Character', 'type': 'object', 'properties': {'name': {'type':'string','maxLength': 10}, 'age': {'type': 'integer'}, 'armor': {'type':'string', 'enum': ['leather', 'chainmail', 'plate']}, 'weapon': {'type':'string', 'enum': ['sword', 'axe','mace','spear', 'bow', 'crossbow']},'strength': {'type': 'integer'}},'required': ['name', 'age', 'armor', 'weapon','strength']}
</schema><|eot_id|><|start_header_id|>user<|end_header_id|>

I'm creating a role-playing game and need to generate character profiles. Can you provide a JSON object for a character with a name, age, armor type, weapon type, and strength level? The name should be no longer than 10 characters, age should be an integer, armor should be one of 'leather', 'chainmail', or 'plate', weapon should be one of'sword', 'axe','mace','spear', 'bow', or 'crossbow', and strength should also be an integer. The character's name will be 'Aldorin', a seasoned warrior of 27 years. He dons a sturdy suit of chainmail armor that has seen many battles. In his hand, he wields a trusty sword, the blade glinting with the promise of protection and the threat of battle. His strength, a testament to his rigorous training and countless skirmishes, is an impressive 16. This level of strength indicates that Aldorin is well above average in physical power, capable of wielding his sword with significant force and skill.<|eot_id|><|start_header_id|>assistant<|end_header_id|>

<think>
Okay, let's see. The user wants me to generate a JSON object based on the character description they provided. The character's name is Aldorin, which is exactly 7 characters long, so that fits the max length of 10. The age is 27, which is an integer. So the age part is straightforward.

Next, armor type. The description says he wears chainmail armor. The options are leather, chainmail, or plate. Chainmail is one of them, so that's good. So armor will be 'chainmail'.

Weapon is a sword. The options include sword, axe, mace, spear, bow, crossbow. Sword is listed, so that's correct. So weapon is'sword'.

Strength level is 16. The user mentioned that 16 is impressive and above average. So strength should be 16. The schema requires strength to be an integer, so that works.

Wait, let me double-check the required fields. The schema specifies name, age, armor, weapon, and strength. All the required properties are covered here. Name is Aldorin, age 27, armor chainmail, weapon sword, strength 16. 

Everything seems to fit the schema. The name is within the 10-character limit. The armor and weapon options are valid. The integers are correctly used. So putting all that into JSON format should be straightforward.

I need to structure the JSON object with the keys matching the schema: name, age, armor, weapon, strength. All values are correctly typed. Let me just make sure I don't introduce any typos. Chainmail is written correctly, sword is correct. Numbers are 27 and 16, so no issues there. The name is exactly as given. 

So the final JSON should look like this:
{
  "name": "Aldorin",
  "age": 27,
  "armor": "chainmail",
  "weapon": "sword",
  "strength": 16
}

That should satisfy all the requirements and match the provided description.
</think>

Here is the JSON object for the character "Aldorin" based on your description:

```json
{
  "name": "Aldorin",
  "age": 27,
  "armor": "chainmail",
  "weapon": "sword",
  "strength": 16
}
```<|eot_id|>
---

## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions
- [ ] If .env vars required, did you add it to the .env.example in repo root?