### PR TITLE
Add pytest workflow for Python 3.10 and 3.12

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,32 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10', '3.12']
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+
+    - name: Run pytest
+      run: |
+        pytest -v


### PR DESCRIPTION
## Summary
- Add GitHub Actions workflow to run pytest on Python 3.10 and 3.12
- Tests run on pull requests and pushes to main branch
- Uses matrix strategy to test both Python versions in parallel

## Test plan
- [ ] Verify GitHub Actions workflow runs successfully
- [ ] Confirm tests pass on both Python 3.10 and 3.12
- [ ] Check that workflow triggers on pull requests

🤖 Generated with [Claude Code](https://claude.ai/code)