### PR TITLE
Fix broken README links and minor typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ https://huggingface.co/NousResearch/DeepHermes-ToolCalling-Specialist-Atropos
 
 
 Environment Used:
-[https://github.com/NousResearch/Atropos/environments/tool_calling_server.py](https://github.com/NousResearch/atropos/blob/main/environments/tool_calling_server.py)
+[https://github.com/NousResearch/Atropos/blob/main/environments/tool_calling_server.py](https://github.com/NousResearch/atropos/blob/main/environments/tool_calling_server.py)
 
 ---
 
@@ -108,7 +108,7 @@ Model Artifact:
 https://huggingface.co/NousResearch/DeepHermes-Financial-Fundamentals-Prediction-Specialist-Atropos
 
 Environment Used:
-[https://github.com/NousResearch/Atropos/environments/fundamental_prediction_environment.py](https://github.com/NousResearch/atropos/blob/main/environments/fundamental_prediction_environment.py)
+[https://github.com/NousResearch/Atropos/blob/main/environments/fundamental_prediction_environment.py](https://github.com/NousResearch/atropos/blob/main/environments/fundamental_prediction_environment.py)
 
 ---
 

--- a/atroposlib/envs/README.md
+++ b/atroposlib/envs/README.md
@@ -62,7 +62,7 @@ These methods have default implementations or are optional based on your needs:
 
 *   **`async def cleanup(self)`**: Called after each call to `handle_env`. You can implement this for any cleanup needed after processing a single item, though it's often not required.
 
-## Overrideable Class Variables
+## Overridable Class Variables
 
 These class-level variables in `BaseEnv` can be overridden in your subclass to customize its behavior:
 


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
│  Select PR type below and fill applicable sections.       │
│  Delete non-applicable sections for your PR type.         │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
<!-- Briefly describe the changes or additions introduced by this pull request. -->
Hey! Just a quick cleanup:
- Fixed dead links to `environments` in `README.md` — now they point to the correct paths.
- Corrected a small typo in `envs/README.md`: changed `Overrideable` to `Overridable`.
<!-- For non-environment PRs -->

### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update
