### PR TITLE
Fix typo in author name Gurning -> Gurung in community README

### DIFF
--- a/environments/community/README.md
+++ b/environments/community/README.md
@@ -293,7 +293,7 @@ A unique environment for training LLMs to express needs and desires through auth
 **Author**: [JakeBoggs](https://github.com/JakeBoggs)
 **Purpose**: Train LLMs to generate humorous punchlines using Verifiable Rewards via Completion Likelihood Improvement (VR-CLI)
 
-A specialized environment for training LLMs to understand humor by generating joke punchlines through a novel RL technique from the paper "Learning to Reason for Long-Form Story Generation" (Gurning & Lapata, 2025). The environment teaches models to first generate reasoning that leads to good punchlines, with rewards based on how much the reasoning improves the likelihood of the actual punchline.
+A specialized environment for training LLMs to understand humor by generating joke punchlines through a novel RL technique from the paper "Learning to Reason for Long-Form Story Generation" (Gurung & Lapata, 2025). The environment teaches models to first generate reasoning that leads to good punchlines, with rewards based on how much the reasoning improves the likelihood of the actual punchline.
 
 **Features**:
 - **VR-CLI Methodology**: Uses Verifiable Rewards via Completion Likelihood Improvement for reduced overfitting


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR fixes a typo in the author's name in environments/community/README.md where "Gurning & Lapata, 2025" is incorrectly written instead of "Gurung & Lapata, 2025" as correctly referenced in the punchline_vrcli/README.md file.
<img width="1310" alt="image" src="https://github.com/user-attachments/assets/d0e8ffa8-9eef-48a4-b8c2-4c323bf4c219" />

### Related Issues
<!-- Link any relevant issues here. Use "Closes #issue_number" to automatically close issues. -->

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings