### PR TITLE
qwen tokenizer wrapper & fixed jinja template for tool handling

### DIFF
--- a/atroposlib/utils/tokenizers/qwen_fixed_tokenizer.py
+++ b/atroposlib/utils/tokenizers/qwen_fixed_tokenizer.py
@@ -1,0 +1,111 @@
+"""
+Custom Qwen tokenizer wrapper with fixed Jinja2 template.
+
+This wrapper overrides the chat_template to avoid Jinja2 sandbox restrictions
+that prevent list.append() operations in the original Qwen tokenizer.
+
+TLDR; tool calls with Qwen are a PITA
+"""
+
+from typing import Any, Dict, List, Optional, Union
+
+from transformers import AutoTokenizer
+
+
+class QwenFixedTokenizer:
+    """Wrapper around Qwen tokenizer with fixed chat template."""
+
+    # Fixed Jinja2 template that avoids sandbox restrictions
+    FIXED_CHAT_TEMPLATE = """{%- if tools %}
+{{- '<|im_start|>system\\n' }}
+{%- if messages[0].role == 'system' %}
+{{- messages[0].content + '\\n\\n' }}
+{%- endif %}
+{{- "# Tools\\n\\nYou may call one or more functions to assist with the user query.\\n\\nYou are provided with function signatures within <tools></tools> XML tags:\\n<tools>" }}
+{%- for tool in tools %}
+{{- "\\n" }}
+{{- tool | tojson }}
+{%- endfor %}
+{{- "\\n</tools>\\n\\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\\n<tool_call>\\n{\\"name\\": <function-name>, \\"arguments\\": <args-json-object>}\\n</tool_call><|im_end|>\\n" }}
+{%- else %}
+{%- if messages[0].role == 'system' %}
+{{- '<|im_start|>system\\n' + messages[0].content + '<|im_end|>\\n' }}
+{%- endif %}
+{%- endif %}
+{%- for message in messages %}
+{%- if message.role == 'user' or (message.role == 'assistant' and message.tool_calls is not defined) or (message.role == 'tool' and loop.index > 1) %}
+{%- if message.role == 'user' %}
+{%- if tools and not loop.first %}
+{{- '<|im_start|>user\\n' + message.content + '<|im_end|>\\n' }}
+{%- elif not tools or (tools and loop.first) %}
+{{- '<|im_start|>user\\n' + message.content + '<|im_end|>\\n' }}
+{%- endif %}
+{%- elif message.role == 'assistant' %}
+{{- '<|im_start|>assistant\\n' + message.content + '<|im_end|>\\n' }}
+{%- elif message.role == 'tool' %}
+{{- '<|im_start|>user\\n<tool_response>\\n' + message.content + '\\n</tool_response><|im_end|>\\n' }}
+{%- endif %}
+{%- elif message.role == 'assistant' and message.tool_calls is defined %}
+{{- '<|im_start|>assistant\\n' }}
+{%- if message.content %}
+{{- message.content + '\\n\\n' }}
+{%- endif %}
+{%- for tool_call in message.tool_calls %}
+{%- if tool_call.function is defined %}
+{{- '<tool_call>\\n{\\"name\\": \\"' + tool_call.function.name + '\\", \\"arguments\\": ' + tool_call.function.arguments + '}\\n</tool_call>' }}
+{%- endif %}
+{%- endfor %}
+{{- '<|im_end|>\\n' }}
+{%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+{{- '<|im_start|>assistant\\n' }}
+{%- endif %}"""  # noqa: E501
+
+    def __init__(self, model_name_or_path: str, **kwargs):
+        """Initialize the tokenizer wrapper.
+
+        Args:
+            model_name_or_path: Model name or path to load tokenizer from
+            **kwargs: Additional arguments passed to AutoTokenizer.from_pretrained
+        """
+        # Load the base tokenizer
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name_or_path, **kwargs)
+
+        # Override the chat template with our fixed version
+        self.tokenizer.chat_template = self.FIXED_CHAT_TEMPLATE
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate all other attributes to the underlying tokenizer."""
+        return getattr(self.tokenizer, name)
+
+    def apply_chat_template(
+        self,
+        conversation: List[Dict[str, str]],
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tokenize: bool = True,
+        padding: bool = False,
+        truncation: bool = False,
+        max_length: Optional[int] = None,
+        return_tensors: Optional[Union[str, bool]] = None,
+        return_dict: bool = False,
+        add_generation_prompt: bool = False,
+        **kwargs,
+    ):
+        """Apply the fixed chat template.
+
+        This method delegates to the underlying tokenizer's apply_chat_template
+        but ensures our fixed template is used.
+        """
+        return self.tokenizer.apply_chat_template(
+            conversation,
+            tools=tools,
+            tokenize=tokenize,
+            padding=padding,
+            truncation=truncation,
+            max_length=max_length,
+            return_tensors=return_tensors,
+            return_dict=return_dict,
+            add_generation_prompt=add_generation_prompt,
+            **kwargs,
+        )


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
│  Select PR type below and fill applicable sections.       │
│  Delete non-applicable sections for your PR type.         │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
<!-- Please check ONE of the following options -->
- [ ] RL Environment PR - Complete Environment Snapshot & Zero-Training sections
- [X] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
Adds a helper/wrapper for the HF AutoTokenizer when using Qwen3 based models. HF jinja template has issues with tool tags in the system prompt (tries to parse them & errors), and if you try the tools param, you get a jinja sandboxing error due to the use of .append(). This wrapper has a fixed jinja template to correctly handle tools (tested, working correctly)

<!-- For non-environment PRs -->
### Related Issues
<!-- Link any relevant issues here. Use "Closes #issue_number" to automatically close issues. -->

### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Code refactor (no functional changes)
- [ ] Build/CI/CD related changes
- [ ] Other (please describe):

---
## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [X] Code follows project style (black, isort, flake8 pass with pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Docstrings added for all new public classes / functions
- [X] If .env vars required, did you add it to the .env.example in repo root?
