### PR TITLE
build: update checkout action to v5

### DIFF
--- a/.github/workflows/check-no-torch.yml
+++ b/.github/workflows/check-no-torch.yml
@@ -15,7 +15,7 @@ jobs:
     name: Ensure torch is not in main dependencies
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Check pyproject.toml for torch in main dependencies
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5

--- a/.github/workflows/upload_to_pypi.yml
+++ b/.github/workflows/upload_to_pypi.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         persist-credentials: false
     - name: Set up Python


### PR DESCRIPTION
Node 24 compatibility: switch all jobs to actions/checkout@v5. Requires runner v2.327.1+. Pure maintenance, behavior unchanged.

Ref: https://github.com/actions/checkout/releases/tag/v5.0.0