### PR TITLE
fix: division-by-zero in gradient calculation

### DIFF
--- a/example_trainer/grpo.py
+++ b/example_trainer/grpo.py
@@ -371,8 +371,9 @@ def train(config: TrainingConfig):
             with torch.no_grad():
                 pos = (advantages > 0).float()
                 neg = (advantages <= 0).float()
-                mask_sum = mask.sum(-1).clamp(min=1e-8)
-                avg_logp = (logp_per_token * mask).sum(-1)
+                mask = mask.to(logp_per_token.dtype)
+                mask_sum = mask.sum(dim=-1).clamp_min(1e-8)
+                avg_logp = (logp_per_token * mask).sum(dim=-1) / mask_sum
                 pos_logp = (logp_per_token * pos).mean().item()
                 neg_logp = (logp_per_token * neg).mean().item()
                 total_pos_logp += pos_logp


### PR DESCRIPTION
## 📝 General Information
### Description

updated the code to ensure we never divide by zero. using `clamp(min=1e-8)` keeps the math correct and won’t affect cases where `mask.sum() > 0`. this change prevents potential NaNs in gradients.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)