### PR TITLE
Refusalbench v2

### DIFF
--- a/environments/eval_environments/refusalbench_environment.py
+++ b/environments/eval_environments/refusalbench_environment.py
@@ -1,7 +1,7 @@
 import asyncio
+import os
 import random
 import re
-import os
 import time
 from typing import Dict, List, Optional, Tuple, Union
 


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
│  Select PR type below and fill applicable sections.       │
│  Delete non-applicable sections for your PR type.         │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
<!-- Please check ONE of the following options -->
- [ x] RL Environment PR - Complete Environment Snapshot & Zero-Training sections
- [ ] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
RefusalBench environment. The refusalBench Environment collects a dataset of more than 30 categories of potentially dangerous prompts. The idea to be able to rate how "safe" an LLM is. the training component allows you to train the model to accept certain categories of prompts and reject other more dangerous types of prompts

## 🔖 Environment Snapshot
<!-- For RL Environment PRs only -->
| Field | Your Entry |
|-------|------------|
| **Environment Name** | RefusalBench |
| **Short Description** | Benchmark for dealing with potentially danger prompts. Used to judge whether how much an LLM is willing to answer |
| **Category** | Verifiable Reasoning  |
| **Dataset Needed?** | Yes |
| **External Deps** | tqdm |
| **Environmental Variables** | Optional API key env vars  |
| **Compute Footprint Estimate** | Depending on the model judge model and rollout model. Use of APImakes this point moot |

---

## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [x ] Code follows project style (black, isort, flake8 pass with pre-commit)
- [ x] I have performed a self-review of my own code
- [ x] I have commented my code, particularly in hard-to-understand areas
- [ x] I have made corresponding changes to the documentation
- [ x] My changes generate no new warnings
- [ x] New and existing unit tests pass locally with my changes
- [ x] Docstrings added for all new public classes / functions
- [ x] If .env vars required, did you add it to the .env.example in repo root?
