### PR TITLE
Move re import to module level in ufc_image_env.py

### DIFF
--- a/environments/community/ufc_prediction_env/ufc_image_env.py
+++ b/environments/community/ufc_prediction_env/ufc_image_env.py
@@ -3,6 +3,7 @@ import csv
 import io
 import os
 import random
+import re
 import sys
 import traceback
 from typing import List, Optional, Tuple
@@ -286,8 +287,6 @@ class UFCImageEnv(BaseEnv):
                 ground_truth_color = ground_truth.replace("answer:", "").strip()
 
                 # Extract color from \boxed{color} format
-                import re
-
                 boxed_match = re.search(r"\\boxed{([^}]+)}", reply)
                 if boxed_match:
                     prediction = boxed_match.group(1).strip().lower()


### PR DESCRIPTION
## PR Type
<!-- Please check ONE of the following options -->
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
Move `import re` from function scope to module level in `ufc_image_env.py` to follow PEP 8 conventions and improve code style. The regex import was previously located inside a function, which violates Python import guidelines and causes unnecessary overhead on each function call.


### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (no functional changes)


## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

