### PR TITLE
Message Passing with ZMQ

### DIFF
--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -1,11 +1,17 @@
+import asyncio
+import os
 import time
 import uuid
+from contextlib import suppress
 from typing import Any, Dict, List, Optional
 
+import wandb
 from fastapi import FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, field_validator
+import zmq
+import zmq.asyncio
 
 from atroposlib.api.utils import (
     find_groups_summing_to_target,
@@ -17,6 +23,9 @@ from atroposlib.api.utils import (
 MIN_ENV_WEIGHT = (
     0.01  # Minimum weight to prevent environments from being completely starved
 )
+
+MESSAGE_BUS_ENABLED = os.getenv("ATROPOS_ENABLE_MESSAGE_BUS", "1") != "0"
+MESSAGE_BUS_ENDPOINT = os.getenv("ATROPOS_MESSAGE_BUS_ENDPOINT", "tcp://0.0.0.0:5759")
 
 # Message import removed - using Dict[str, Any] for more flexible validation
 
@@ -114,6 +123,108 @@ class Info(BaseModel):
     batch_size: int = -1
 
 
+async def _log_metrics(message: Dict[str, Any]) -> None:
+    if not getattr(app.state, "wandb_enabled", False):
+        return
+    if getattr(app.state, "wandb_run", None) is None:
+        return
+
+    wandb_prepend = message.get("wandb_prepend")
+    metrics = message.get("metrics") or {}
+    server_metrics = message.get("server_metrics") or {}
+    rollouts = message.get("rollouts") or []
+    step = message.get("step")
+
+    metrics_to_log: Dict[str, Any] = {}
+    if wandb_prepend:
+        metrics_to_log.update({f"{wandb_prepend}_{k}": v for k, v in metrics.items()})
+    else:
+        metrics_to_log.update(metrics)
+
+    metrics_to_log.update(server_metrics)
+
+    if rollouts:
+        table = wandb.Table(columns=["text", "score"])
+        for entry in rollouts:
+            if isinstance(entry, list):
+                for text, score in entry:
+                    table.add_data(text, score)
+            else:
+                text, score = entry
+                table.add_data(text, score)
+        table_key = "train/rollouts"
+        if wandb_prepend:
+            table_key = f"{wandb_prepend}_{table_key}"
+        metrics_to_log[table_key] = table
+
+    async with app.state.wandb_lock:  # type: ignore[attr-defined]
+        await asyncio.to_thread(wandb.log, metrics_to_log, step=step)
+
+
+async def _message_bus_worker() -> None:
+    socket = getattr(app.state, "message_bus_socket", None)
+    if socket is None:
+        return
+
+    while True:
+        try:
+            message = await socket.recv_json()
+        except asyncio.CancelledError:
+            break
+        except Exception:
+            continue
+
+        token = message.get("token")
+        if token is None:
+            continue
+        env_record = getattr(app.state, "message_bus_tokens", {}).get(token)
+        if env_record is None:
+            continue
+
+        msg_type = message.get("type")
+        if msg_type == "metrics":
+            await _log_metrics(message)
+
+
+@app.on_event("startup")
+async def startup_event() -> None:
+    if MESSAGE_BUS_ENABLED:
+        context = zmq.asyncio.Context.instance()
+        socket = context.socket(zmq.PULL)
+        socket.setsockopt(zmq.LINGER, 0)
+        socket.setsockopt(zmq.RCVHWM, 0)
+        socket.bind(MESSAGE_BUS_ENDPOINT)
+        app.state.message_bus_context = context
+        app.state.message_bus_socket = socket
+        app.state.message_bus_tokens = {}
+        app.state.message_bus_endpoint = MESSAGE_BUS_ENDPOINT
+        app.state.message_bus_task = asyncio.create_task(_message_bus_worker())
+
+    app.state.wandb_run = None
+    app.state.wandb_enabled = False
+    app.state.wandb_lock = asyncio.Lock()
+
+
+@app.on_event("shutdown")
+async def shutdown_event() -> None:
+    message_bus_task = getattr(app.state, "message_bus_task", None)
+    if message_bus_task:
+        message_bus_task.cancel()
+        with suppress(Exception):
+            await message_bus_task
+    socket = getattr(app.state, "message_bus_socket", None)
+    if socket is not None:
+        socket.close(linger=0)
+        app.state.message_bus_socket = None
+    if getattr(app.state, "wandb_run", None) is not None:
+        wandb.finish()
+        app.state.wandb_run = None
+    if getattr(app.state, "message_bus_context", None) is not None:
+        context = app.state.message_bus_context
+        context.term()
+        app.state.message_bus_context = None
+
+
 @app.post("/register")
 async def register(registration: Registration):
     # Initialize app state if not already done
@@ -131,6 +242,26 @@ async def register(registration: Registration):
         app.state.started = False
         app.state.envs = []
         app.state.buffer = {}  # Buffer for mixed-size groups per environment
+    if MESSAGE_BUS_ENABLED:
+        app.state.wandb_enabled = True
+        if getattr(app.state, "wandb_run", None) is not None:
+            wandb.finish()
+        wandb_mode = os.getenv("WANDB_MODE")
+        if wandb_mode is None and not os.getenv("WANDB_API_KEY"):
+            wandb_mode = "disabled"
+        init_kwargs: Dict[str, Any] = {
+            "project": registration.wandb_project,
+            "group": registration.wandb_group,
+            "config": {
+                "batch_size": registration.batch_size,
+                "max_token_len": registration.max_token_len,
+                "num_steps": registration.num_steps,
+            },
+            "settings": wandb.Settings(start_method="thread"),
+        }
+        if wandb_mode is not None:
+            init_kwargs["mode"] = wandb_mode
+        app.state.wandb_run = wandb.init(**init_kwargs)
 
     # Initialize requesters list if not already done
     if not hasattr(app.state, "requesters"):
@@ -172,7 +303,7 @@ async def register_env_url(register_env: RegisterEnv):
             "group_size": register_env.group_size,
         }
     )
-    return {
+    response = {
         "status": "success",
         "env_id": registered_id,
         "wandb_name": real_name,
@@ -181,12 +312,35 @@ async def register_env_url(register_env: RegisterEnv):
         "checkpoint_interval": app.state.save_checkpoint_interval,
         "num_steps": app.state.num_steps,
     }
+    if (
+        MESSAGE_BUS_ENABLED
+        and getattr(app.state, "message_bus_endpoint", None) is not None
+    ):
+        token = uuid.uuid4().hex
+        app.state.envs[registered_id]["message_token"] = token
+        if getattr(app.state, "message_bus_tokens", None) is None:
+            app.state.message_bus_tokens = {}
+        app.state.message_bus_tokens[token] = {
+            "registered_id": registered_id,
+            "desired_name": register_env.desired_name,
+            "real_name": real_name,
+        }
+        response["message_bus"] = {
+            "endpoint": app.state.message_bus_endpoint,
+            "token": token,
+            "env_name": register_env.desired_name,
+            "wandb_prepend": real_name,
+        }
+    return response
 
 
 @app.post("/disconnect-env")
 async def disconnect_env(disconnect_env: EnvIdentifier):
     try:
         app.state.envs[disconnect_env.env_id]["connected"] = False
+        token = app.state.envs[disconnect_env.env_id].get("message_token")
+        if token and getattr(app.state, "message_bus_tokens", None) is not None:
+            app.state.message_bus_tokens.pop(token, None)
         return {"status": "success"}
     except (AttributeError, IndexError) as e:
         return {"status": "failure", "error": str(e)}
@@ -533,6 +687,14 @@ async def reset_data():
         app.state.requesters = []
         app.state.envs = []
         app.state.buffer = {}
+        if getattr(app.state, "message_bus_tokens", None) is not None:
+            app.state.message_bus_tokens.clear()
     except KeyError:
         pass
+    if getattr(app.state, "wandb_run", None) is not None:
+        wandb.finish()
+        app.state.wandb_run = None
+    app.state.wandb_enabled = MESSAGE_BUS_ENABLED and getattr(
+        app.state, "message_bus_socket", None
+    ) is not None
     return PlainTextResponse("Reset successful", status_code=status.HTTP_200_OK)

--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -6,12 +6,12 @@ from contextlib import suppress
 from typing import Any, Dict, List, Optional
 
 import wandb
+import zmq
+import zmq.asyncio
 from fastapi import FastAPI, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, field_validator
-import zmq
-import zmq.asyncio
 
 from atroposlib.api.utils import (
     find_groups_summing_to_target,
@@ -694,7 +694,8 @@ async def reset_data():
     if getattr(app.state, "wandb_run", None) is not None:
         wandb.finish()
         app.state.wandb_run = None
-    app.state.wandb_enabled = MESSAGE_BUS_ENABLED and getattr(
-        app.state, "message_bus_socket", None
-    ) is not None
+    app.state.wandb_enabled = (
+        MESSAGE_BUS_ENABLED
+        and getattr(app.state, "message_bus_socket", None) is not None
+    )
     return PlainTextResponse("Reset successful", status_code=status.HTTP_200_OK)

--- a/atroposlib/tests/test_message_bus.py
+++ b/atroposlib/tests/test_message_bus.py
@@ -1,0 +1,235 @@
+import asyncio
+import socket
+import sys
+import time
+import types
+from types import SimpleNamespace
+from typing import Any, Dict, List, Optional, Tuple
+
+import numpy as np
+import pytest
+from fastapi.testclient import TestClient
+
+try:
+    import wandb  # type: ignore
+except ModuleNotFoundError:  # pragma: no cover
+    wandb = types.SimpleNamespace(
+        Settings=lambda **kwargs: SimpleNamespace(**kwargs),
+        Table=lambda *args, **kwargs: None,
+        init=lambda **kwargs: None,
+        log=lambda *args, **kwargs: None,
+        finish=lambda *args, **kwargs: None,
+    )
+    sys.modules["wandb"] = wandb
+
+from atroposlib.api import server
+from atroposlib.envs.base import BaseEnv
+from atroposlib.utils.message_bus import MessageBusClient
+
+
+def _get_free_tcp_port() -> int:
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return port
+
+
+class DummyTable:
+    def __init__(self, columns: List[str]):
+        self.columns = columns
+        self.rows: List[Tuple[Any, ...]] = []
+
+    def add_data(self, *values: Any) -> None:
+        self.rows.append(values)
+
+
+def test_api_message_bus_routes_metrics_to_wandb(monkeypatch):
+    port = _get_free_tcp_port()
+    endpoint = f"tcp://127.0.0.1:{port}"
+
+    monkeypatch.setattr(server, "MESSAGE_BUS_ENABLED", True)
+    monkeypatch.setattr(server, "MESSAGE_BUS_ENDPOINT", endpoint)
+
+    init_calls: List[Dict[str, Any]] = []
+    logged_calls: List[Tuple[Dict[str, Any], Any]] = []
+
+    monkeypatch.setattr(server.wandb, "Table", DummyTable)
+    monkeypatch.setattr(
+        server.wandb,
+        "init",
+        lambda **kwargs: init_calls.append(kwargs) or object(),
+    )
+    monkeypatch.setattr(server.wandb, "log", lambda metrics, step=None: logged_calls.append((metrics, step)))
+    monkeypatch.setattr(server.wandb, "finish", lambda *args, **kwargs: None)
+
+    with TestClient(server.app) as client:
+        response = client.post(
+            "/register",
+            json={
+                "wandb_group": "test_group",
+                "wandb_project": "test_project",
+                "batch_size": 4,
+                "max_token_len": 128,
+                "checkpoint_dir": "/tmp",
+                "save_checkpoint_interval": 10,
+                "starting_step": 0,
+                "num_steps": 100,
+            },
+        )
+        assert response.status_code == 200
+        assert init_calls, "wandb.init should be invoked during trainer registration"
+
+        env_response = client.post(
+            "/register-env",
+            json={
+                "max_token_length": 128,
+                "desired_name": "env",
+                "weight": 1.0,
+                "group_size": 2,
+                "min_batch_allocation": None,
+            },
+        )
+        data = env_response.json()
+        assert env_response.status_code == 200
+        message_bus = data.get("message_bus")
+        assert message_bus, "message bus details should be returned when enabled"
+        assert message_bus["endpoint"] == endpoint
+
+        bus_client = MessageBusClient(
+            endpoint=message_bus["endpoint"],
+            token=message_bus["token"],
+        )
+        payload = {
+            "type": "metrics",
+            "metrics": {"train/foo": 1.0},
+            "server_metrics": {"server_metric": 2.0},
+            "rollouts": [["hello world", 0.5]],
+            "step": 5,
+            "wandb_prepend": message_bus["wandb_prepend"],
+        }
+        asyncio.run(bus_client.send_json(payload))
+        asyncio.run(bus_client.close())
+
+        for _ in range(20):
+            if logged_calls:
+                break
+            time.sleep(0.05)
+
+        assert logged_calls, "Metrics sent over the message bus should reach wandb.log"
+        metrics_logged, step_logged = logged_calls[-1]
+        expected_prefix = message_bus["wandb_prepend"]
+        assert metrics_logged[f"{expected_prefix}_train/foo"] == 1.0
+        assert metrics_logged["server_metric"] == 2.0
+        rollout_key = f"{expected_prefix}_train/rollouts"
+        assert rollout_key in metrics_logged
+        assert metrics_logged[rollout_key].rows[0] == ("hello world", 0.5)
+        assert step_logged == 5
+
+        client.get("/reset_data")
+
+
+class DummyMessageBusClient:
+    def __init__(self):
+        self.messages: List[Dict[str, Any]] = []
+
+    async def send_json(self, payload: Dict[str, Any]) -> None:
+        self.messages.append(payload)
+
+
+class DummyServer:
+    async def wandb_metrics(self, metrics_dict: Optional[Dict[str, Any]], server_name: Optional[str]):
+        metrics_dict = metrics_dict or {}
+        metrics_dict[f"{server_name}_latency"] = np.float32(3.25)
+        return metrics_dict
+
+
+def _build_dummy_env(use_bus: bool, monkeypatch) -> Tuple[Any, DummyMessageBusClient]:
+    dummy_client = DummyMessageBusClient() if use_bus else None
+
+    server_manager = SimpleNamespace(servers=[DummyServer()])
+    config = SimpleNamespace(
+        use_wandb=True,
+        num_rollouts_per_group_for_logging=1,
+        group_size=2,
+        num_rollouts_to_keep=8,
+    )
+
+    dummy = SimpleNamespace(
+        server=server_manager,
+        message_bus_client=dummy_client,
+        config=config,
+        completion_lengths=[1, 3],
+        rollouts_for_wandb=[[("decoded text", 0.9)]],
+        max_token_len=128,
+        wandb_prepend="env_0",
+        curr_step=7,
+        env_id=42,
+        message_bus_env_name="env",
+        message_bus_wandb_prepend="env_0",
+        task_duration=[0.5, 0.7],
+        succeeded_task_duration=[0.3, 0.4],
+        failed_task_duration=[],
+        mainloop_timings=[0.1, 0.2],
+        workers_added_list=[1, 2],
+    )
+
+    dummy._sanitize_for_json = BaseEnv._sanitize_for_json.__get__(dummy, BaseEnv)
+    dummy.create_rollout_table = BaseEnv.create_rollout_table.__get__(dummy, BaseEnv)
+    dummy.perf_stats = BaseEnv.perf_stats.__get__(dummy, BaseEnv)
+
+    if not use_bus:
+        monkeypatch.setattr("atroposlib.envs.base.wandb.Table", DummyTable)
+
+    return dummy, dummy_client
+
+
+def test_base_env_wandb_log_uses_message_bus(monkeypatch):
+    dummy_env, dummy_client = _build_dummy_env(use_bus=True, monkeypatch=monkeypatch)
+
+    def fail_log(*args, **kwargs):
+        raise AssertionError("wandb.log should not be called when message bus is active")
+
+    monkeypatch.setattr("atroposlib.envs.base.wandb.log", fail_log)
+
+    asyncio.run(
+        BaseEnv.wandb_log(
+            dummy_env,
+            {"custom_metric": np.float32(1.5)},
+        )
+    )
+
+    assert dummy_client.messages, "Message bus client should receive payloads"
+    payload = dummy_client.messages[0]
+    assert payload["env_id"] == 42
+    assert payload["metrics"]["custom_metric"] == pytest.approx(1.5)
+    assert payload["server_metrics"]["server_0_latency"] == pytest.approx(3.25)
+    assert payload["rollouts"][0][0][0] == "decoded text"
+    assert dummy_env.rollouts_for_wandb == []
+    assert dummy_env.completion_lengths == []
+
+
+def test_base_env_wandb_log_falls_back_to_local_wandb(monkeypatch):
+    dummy_env, _ = _build_dummy_env(use_bus=False, monkeypatch=monkeypatch)
+
+    logged_calls: List[Tuple[Dict[str, Any], Any]] = []
+
+    monkeypatch.setattr(
+        "atroposlib.envs.base.wandb.log",
+        lambda metrics, step=None: logged_calls.append((metrics, step)),
+    )
+
+    asyncio.run(
+        BaseEnv.wandb_log(
+            dummy_env,
+            {"local_metric": 2.0},
+        )
+    )
+
+    assert logged_calls, "wandb.log should be called when message bus is absent"
+    metrics_logged, step_logged = logged_calls[0]
+    assert metrics_logged["env_0_local_metric"] == 2.0
+    rollout_table = metrics_logged["env_0_train/rollouts"]
+    assert isinstance(rollout_table, DummyTable)
+    assert rollout_table.rows[0] == ("decoded text", 0.9)
+    assert step_logged == 7

--- a/atroposlib/utils/message_bus.py
+++ b/atroposlib/utils/message_bus.py
@@ -1,0 +1,57 @@
+import asyncio
+from typing import Any, Dict
+
+import zmq
+import zmq.asyncio
+
+
+class MessageBusClient:
+    """ZMQ client used by environments to publish payloads."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        token: str,
+        *,
+        linger: int = 0,
+        snd_hwm: int = 0,
+    ) -> None:
+        self._endpoint = endpoint
+        self._token = token
+        self._context = zmq.asyncio.Context.instance()
+        self._socket = self._context.socket(zmq.PUSH)
+        self._socket.setsockopt(zmq.LINGER, linger)
+        if snd_hwm >= 0:
+            self._socket.setsockopt(zmq.SNDHWM, snd_hwm)
+        self._socket.connect(endpoint)
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    @property
+    def endpoint(self) -> str:
+        return self._endpoint
+
+    @property
+    def token(self) -> str:
+        return self._token
+
+    async def send_json(self, payload: Dict[str, Any]) -> None:
+        """Send a JSON serialisable payload over the message bus."""
+        if self._closed:
+            return
+        message = dict(payload)
+        message.setdefault("token", self._token)
+        async with self._lock:
+            await self._socket.send_json(message)
+
+    async def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        self._socket.close(linger=0)
+
+    def __del__(self) -> None:
+        try:
+            self._socket.close(linger=0)
+        except Exception:
+            pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "markdown",
     "numpy",
     "wandb",
+    "pyzmq",
     "gymnasium",
     "math-verify==0.7.0",
     "jinja2",


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
│  Select PR type below and fill applicable sections.       │
│  Delete non-applicable sections for your PR type.         │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
<!-- Please check ONE of the following options -->
- [ ] RL Environment PR - Complete Environment Snapshot & Zero-Training sections
- [X] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
<!-- Briefly describe the changes or additions introduced by this pull request. -->
This PR introduces a ZMQ integration in the Atropos API to create a message bus that aggregates rollout data from instances of the same environment to push for WandB. 

<!-- For non-environment PRs -->
### Related Issues
<!-- Link any relevant issues here. Use "Closes #issue_number" to automatically close issues. -->

### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update
- [ ] Code refactor (no functional changes)
- [ ] Build/CI/CD related changes
- [ ] Other (please describe):
---

## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [X] Code follows project style (black, isort, flake8 pass with pre-commit)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] New and existing unit tests pass locally with my changes
- [X] Docstrings added for all new public classes / functions
- [ ] If .env vars required, did you add it to the .env.example in repo root?
