### PR TITLE
docs: fix BibTeX citation format to avoid LaTeX compilation errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ If you have found the library helpful in your work, you can cite this repository
 @misc{atropos,
   title        = {Atropos: An Async First Environment Rollout Controller},
   author       = {Mahan, Dakota and Jin, Roger and Teknium and Sands, Shannon and Yatsenko, Artem and Suphavadeeprasit, Jai and Malhotra, Karan and Guang, Chen and Li, Joe},
-  howpublished = {\url{https://www.github.com/NousResearch/atropos}},
+  howpublished = {GitHub: https://github.com/NousResearch/atropos},
   year         = {2025},
   month        = {apr},
   note         = {Version 0.3.0},


### PR DESCRIPTION
## Summary
Fixes the BibTeX citation format in README.md to avoid LaTeX compilation errors.

## Problem
The current citation uses `\url{}` command which requires the `hyperref` or `url` package. Users who copy-paste the citation without these packages get LaTeX compilation errors.

## Solution
- Removed `\url{}` wrapper
- Removed `www.` prefix (standard GitHub URL is `github.com`)
- Added descriptive `GitHub:` prefix for clarity

## Before
howpublished = {\url{https://www.github.com/NousResearch/atropos}},## After
howpublished = {GitHub: https://github.com/NousResearch/atropos},## Testing
✅ BibTeX format is now package-independent and works in any LaTeX compiler

## Impact
- Users can copy-paste citation without LaTeX errors
- No package dependencies required
- Cleaner, more standard format