### PR TITLE
chore: bump license year to 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 Nous Research
+Copyright (c) 2026 Nous Research
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
New Year Update!

This PR updates the copyright year from 2025 to 2026 in the license files.

Happy coding in 2026!