### PR TITLE
fix: improve NotImplementedError message for single_file=False

### DIFF
--- a/environments/community/pytorch_optimizer_coding/FOB/pytorch_fob/engine/engine.py
+++ b/environments/community/pytorch_optimizer_coding/FOB/pytorch_fob/engine/engine.py
@@ -139,7 +139,9 @@ class Engine:
             else:
                 # TODO: option to split into multiple files
                 raise NotImplementedError(
-                    "evaluation.plot.single_file=False is not implemented yet."
+                    "evaluation.plot.single_file=False is not implemented yet. "
+                    "To create multiple subplots in a single file, use 'split_groups' or 'column_split_key' instead. "
+                    "See evaluation/default.yaml for configuration options."
                 )
         return figs
 


### PR DESCRIPTION
## Description

Improves the error message when `evaluation.plot.single_file=False` is used, which is currently not implemented.

## Changes

- Enhanced `NotImplementedError` message in `Engine.plot()` method to suggest alternative configuration options (`split_groups`, `column_split_key`) and reference the configuration documentation