### PR TITLE
fix: use correct prefix for gradient quantiles with NaN/Inf

### DIFF
--- a/environments/community/pytorch_optimizer_coding/FOB/pytorch_fob/engine/callbacks.py
+++ b/environments/community/pytorch_optimizer_coding/FOB/pytorch_fob/engine/callbacks.py
@@ -291,7 +291,7 @@ class LogTrainingStats(Callback):
                                     and grad_data.size().numel() < 10000000
                                 ):
                                     for q_idx, _ in enumerate(q):
-                                        stats[f"param/{name}/quantile-{q[q_idx]}"] = -10
+                                        stats[f"grad/{name}/quantile-{q[q_idx]}"] = -10
 
                             stats[f"grad/{name}/mean"] = grad_data.mean().item()
                             if len(grad_data.shape) > 1 or grad_data.shape[0] > 1:


### PR DESCRIPTION
## Description

Fixes incorrect metric prefix when logging gradient quantiles for NaN/Inf values. The quantiles were being logged under `param/` prefix instead of `grad/`, causing misclassification in training statistics.

## Changes

- Changed metric prefix from `param/` to `grad/` for gradient quantiles with NaN/Inf values (line 294)
- Ensures consistency with other gradient metrics and prevents overwriting parameter quantiles