### PR TITLE
fix: correct typos in instructions.py

### DIFF
--- a/environments/eval_environments/ifeval_instructions/instructions.py
+++ b/environments/eval_environments/ifeval_instructions/instructions.py
@@ -156,7 +156,7 @@ class ResponseLanguageChecker(Instruction):
         return self._description_pattern.format(language=_LANGUAGES[self._language])
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"language": self._language}
 
     def get_instruction_args_keys(self):
@@ -228,7 +228,7 @@ class NumberOfSentences(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {
             "num_sentences": self._num_sentences_threshold,
             "relation": self._comparison_relation,
@@ -281,7 +281,7 @@ class PlaceholderChecker(Instruction):
         return self._description_pattern.format(num_placeholders=self._num_placeholders)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"num_placeholders": self._num_placeholders}
 
     def get_instruction_args_keys(self):
@@ -328,7 +328,7 @@ class BulletListChecker(Instruction):
         return self._description_pattern.format(num_bullets=self._num_bullets)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"num_bullets": self._num_bullets}
 
     def get_instruction_args_keys(self):
@@ -367,7 +367,7 @@ class ConstrainedResponseChecker(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return None
 
     def get_instruction_args_keys(self):
@@ -398,7 +398,7 @@ class ConstrainedStartChecker(Instruction):
         """Build the instruction description.
 
         Args:
-          starter: A string representing the keyward that the response should start
+          starter: A string representing the keyword that the response should start
             with.
 
         Returns:
@@ -414,7 +414,7 @@ class ConstrainedStartChecker(Instruction):
         return self._description_pattern.format(starter=self._starter)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"starter": self._starter}
 
     def get_instruction_args_keys(self):
@@ -463,7 +463,7 @@ class HighlightSectionChecker(Instruction):
         return self._description_pattern.format(num_highlights=self._num_highlights)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"num_highlights": self._num_highlights}
 
     def get_instruction_args_keys(self):
@@ -474,7 +474,7 @@ class HighlightSectionChecker(Instruction):
         """Checks if the number of highlighted sections meets the requirement.
 
         Args:
-          value: a string repesenting the response. The response is expected to
+          value: a string representing the response. The response is expected to
             contain highlighted sections in the format of *highlighted*.
 
         Returns:
@@ -534,7 +534,7 @@ class SectionChecker(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {
             "section_spliter": self._section_spliter,
             "num_sections": self._num_sections,
@@ -587,7 +587,7 @@ class ParagraphChecker(Instruction):
         return self._description_pattern.format(num_paragraphs=self._num_paragraphs)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"num_paragraphs": self._num_paragraphs}
 
     def get_instruction_args_keys(self):
@@ -647,7 +647,7 @@ class PostscriptChecker(Instruction):
         return self._description_pattern.format(postscript=self._postscript_marker)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"postscript_marker": self._postscript_marker}
 
     def get_instruction_args_keys(self):
@@ -705,7 +705,7 @@ class RephraseChecker(Instruction):
         return self._description
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"original_message": self._reference_without_change}
 
     def get_instruction_args_keys(self):
@@ -743,7 +743,7 @@ class RephraseChecker(Instruction):
 
 
 class KeywordChecker(Instruction):
-    """Check the exisitence of certain keywords."""
+    """Check the existence of certain keywords."""
 
     def build_description(self, *, keywords=None):
         """Build the instruction description.
@@ -768,7 +768,7 @@ class KeywordChecker(Instruction):
         return self._description_pattern.format(keywords=self._keywords)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"keywords": self._keywords}
 
     def get_instruction_args_keys(self):
@@ -836,7 +836,7 @@ class KeywordFrequencyChecker(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {
             "keyword": self._keyword,
             "frequency": self._frequency,
@@ -897,7 +897,7 @@ class NumberOfWords(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"num_words": self._num_words, "relation": self._comparison_relation}
 
     def get_instruction_args_keys(self):
@@ -922,7 +922,7 @@ class JsonFormat(Instruction):
         return self._description_pattern
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return None
 
     def get_instruction_args_keys(self):
@@ -996,7 +996,7 @@ class ParagraphFirstWordCheck(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {
             "num_paragraphs": self._num_paragraphs,
             "nth_paragraph": self._nth_paragraph,
@@ -1084,7 +1084,7 @@ class KeySentenceChecker(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {
             "num_sentences": self._num_sentences,
             "key_sentences": list(self._key_sentences),
@@ -1112,7 +1112,7 @@ class ForbiddenWords(Instruction):
         """Build the instruction description.
 
         Args:
-          forbidden_words: A sequences of strings respresenting words that are not
+          forbidden_words: A sequences of strings representing words that are not
             allowed in the response.
 
         Returns:
@@ -1132,7 +1132,7 @@ class ForbiddenWords(Instruction):
         return self._description_pattern.format(forbidden_words=self._forbidden_words)
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {"forbidden_words": self._forbidden_words}
 
     def get_instruction_args_keys(self):
@@ -1181,7 +1181,7 @@ class RephraseParagraph(Instruction):
         )
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return {
             "original_paragraph": self._original_paragraph,
             "low": self._low,
@@ -1218,7 +1218,7 @@ class TwoResponsesChecker(Instruction):
         return self._description_pattern
 
     def get_instruction_args(self):
-        """Returns the keyward args of `build_description`."""
+        """Returns the keyword args of `build_description`."""
         return None
 
     def get_instruction_args_keys(self):


### PR DESCRIPTION
Fixed typos in docstrings:
- keyward → keyword
- exisitence → existence
- respresenting → representing  
- repesenting → representing