### PR TITLE
docs: add python3 venv command alternative for Linux users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,10 @@ We follow the [GitHub Flow](https://docs.github.com) development workflow. All c
     # Ensure you have Python 3.10+ installed
     # Create and activate a virtual environment
     python -m venv .venv
+
+    # Note: If you are on Ubuntu/WSL and get a "command not found" error, use python3:
+    python3 -m venv .venv
+
     source .venv/bin/activate  # On Windows use `.venv\Scripts\activate`
 
     # Install dependencies, including development dependencies


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
│  Select PR type below and fill applicable sections.       │
│  Delete non-applicable sections for your PR type.         │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [ ] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
<!-- Briefly describe the changes or additions introduced by this pull request. -->
I am setting up on Linux (WSL) and python command was missing. Suggesting python3 as an alternative to help new users.
<!-- For non-environment PRs -->

### Type of Change
<!-- For non-environment PRs - delete options that are not relevant. -->
- [ ] This change requires a documentation update


## ✅ Developer & Reviewer Checklist
<!-- Common checklist for all PR types - adapt as needed for your PR type -->
- [ ] Code follows project style (black, isort, flake8 pass with pre-commit)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
- [ ] Docstrings added for all new public classes / functions
- [ ] If .env vars required, did you add it to the .env.example in repo root?
