### PR TITLE
fix: initialize current_item in __init__ to prevent AttributeError

### DIFF
--- a/environments/dataset_environment/dataset_env.py
+++ b/environments/dataset_environment/dataset_env.py
@@ -78,6 +78,7 @@ class DatasetEnv(BaseEnv):
         self.metric_buffer = {}
 
         self.reward_function = self._initialize_reward_function()
+        self.current_item = None
 
     def _initialize_reward_function(self):
         if hasattr(self.config, "reward_functions") and self.config.reward_functions:


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information

Initialize `self.current_item` instance variable in `DatasetEnv.__init__()` to prevent `AttributeError`

**Problem:** `score()` reads `self.current_item`, but this variable is never initialized in `__init__`

**Solution:** Add `self.current_item = None` in `__init__`


### Related Issues
N/A - Code quality improvement discovered during code review

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (no functional changes)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

---

## 🧪 Local Test Results

<img width="1861" height="812" alt="run" src="https://github.com/user-attachments/assets/6bd0c5d9-c18f-490a-85e5-1f0a15b940da" />

**Test Summary:**
- ✅ Pre-commit: All checks passed
- ✅ Pytest: 109 tests passed, 4 skipped
- ✅ No failures or warnings

All checks passed locally!