### PR TITLE
fix: guard metric stats against NaN/Inf and empty inputs

### DIFF
--- a/atroposlib/utils/metrics.py
+++ b/atroposlib/utils/metrics.py
@@ -14,8 +14,19 @@ def get_std_min_max_avg(name: str, data: list, metrics_dict: dict) -> dict:
     Returns:
         The updated metrics dictionary with added statistics (mean, std, max, min).
     """
-    metrics_dict[f"{name}_mean"] = np.mean(data)
-    metrics_dict[f"{name}_std"] = np.std(data)
-    metrics_dict[f"{name}_max"] = np.max(data)
-    metrics_dict[f"{name}_min"] = np.min(data)
+    arr = np.asarray(data, dtype=float)
+    arr = arr[np.isfinite(arr)]  # drop NaN/Inf values
+
+    if arr.size == 0:
+        # Avoid crashes and keep metric keys stable
+        metrics_dict[f"{name}_mean"] = float("nan")
+        metrics_dict[f"{name}_std"] = float("nan")
+        metrics_dict[f"{name}_max"] = float("nan")
+        metrics_dict[f"{name}_min"] = float("nan")
+        return metrics_dict
+
+    metrics_dict[f"{name}_mean"] = float(np.mean(arr))
+    metrics_dict[f"{name}_std"] = float(np.std(arr))
+    metrics_dict[f"{name}_max"] = float(np.max(arr))
+    metrics_dict[f"{name}_min"] = float(np.min(arr))
     return metrics_dict


### PR DESCRIPTION
### What does this PR do?

This PR makes metric aggregation more robust by handling edge cases that can
cause crashes or incorrect logging.

### Changes
- Filter NaN/Inf values before computing statistics
- Gracefully handle empty inputs
- Keep metric keys stable to avoid downstream logging issues

### Why?
Metric computation can receive invalid or empty inputs in edge cases.
This fix prevents runtime errors and ensures consistent logging behavior.
