### PR TITLE
Fix trailing whitespace in README after pre-commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,21 @@ If you have found the library helpful in your work, you can cite this repository
   note         = {Version 0.3.0},
 }
 ```
+### Windows Setup Notes
+
+If you are using Windows, follow these extra steps to avoid common setup issues:
+
+1. **Install Python 3.10+**
+   - Download from [python.org](https://www.python.org/downloads/).
+   - During installation, **check "Add Python to PATH"**.
+
+2. **Disable the Microsoft Store Python alias**
+   - Open **Start → App execution aliases**
+   - Turn **OFF** `python.exe` and `python3.exe`
+
+3. **Allow local scripts in PowerShell** (needed to activate virtual environments)
+   ```powershell
+   Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
 
 ---
 


### PR DESCRIPTION
### Add Windows setup instructions


Added beginner-friendly Windows setup instructions to the README. Includes:

Python 3.10+ installation and PATH setup

Disabling Microsoft Store Python alias

PowerShell execution policy for venv activation

Installing dependencies, pre-commit hooks, and running pytest (skipping API tests)

Related Issues

None (first contribution / documentation improvement)

Type of Change

 This change requires a documentation update

✅ Developer & Reviewer Checklist

 Code follows project style (black, isort, flake8 pass with pre-commit)

 I have performed a self-review of my own code

 I have made corresponding changes to the documentation

 My changes generate no new warnings
