### PR TITLE
fix: replace debug print statements with logger

### DIFF
--- a/environments/dataset_environment/dataset_env.py
+++ b/environments/dataset_environment/dataset_env.py
@@ -241,7 +241,7 @@ class DatasetEnv(BaseEnv):
             top_p=self.config.top_p,
         )
 
-        print(f"Completions: {completions}")
+        logger.debug(f"Completions: {completions}")
         # Process completions
         trajectories = []
         for completion in completions.choices:

--- a/environments/infinimath/infinimath_env.py
+++ b/environments/infinimath/infinimath_env.py
@@ -539,7 +539,7 @@ class InfiniteMathEnv(BaseEnv):
                 if hasattr(completion, "text")
                 else completion.message.content
             )
-            print("model_answer", model_answer)
+            logger.debug(f"model_answer: {model_answer}")
 
             full_messages = [
                 {"role": "system", "content": self.system_prompt},


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

## 📝 General Information

### Description
Replaced leftover debug `print()` statements with proper `logger.debug()` calls in two environment files:

- `environments/dataset_environment/dataset_env.py` (line 244):
  `print(f"Completions: {completions}")` → `logger.debug(f"Completions: {completions}")`
- `environments/infinimath/infinimath_env.py` (line 542):
  `print("model_answer", model_answer)` → `logger.debug(f"model_answer: {model_answer}")`

### Problem
Debug print statements in production code flood stdout with potentially large outputs (especially raw completions data) and bypass the logging framework's level filtering.

### Solution
Replace with `logger.debug()` to respect log level configuration.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (no functional changes)

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings