### PR TITLE
fix: replace debug print with logger in smolagents_env

### DIFF
--- a/environments/smolagents_integration/smolagents_env.py
+++ b/environments/smolagents_integration/smolagents_env.py
@@ -145,10 +145,9 @@ class SmolagentsEnv(BaseEnv):
         if config.data_path_to_save_groups is None:
             timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
             config.data_path_to_save_groups = f"smolagents_output_{timestamp}.jsonl"
-            print(
+            logger.info(
                 f"Using auto-generated output path: {config.data_path_to_save_groups}"
             )
-
         # Initialize the base class
         super().__init__(config, server_configs, slurm, testing)
 


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

## Description
Replaced a leftover `print()` statement with `logger.info()` in smolagents environment.

- `environments/smolagents_integration/smolagents_env.py` (line 148):
  `print(f"Using auto-generated output path: ...")` → `logger.info(f"Using auto-generated output path: ...")`

## Problem
Debug print statement in production code bypasses the logging framework's level filtering.

## Solution
Replace with `logger.info()` to respect log level configuration. Used `info` level since this message communicates useful runtime configuration to the user.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (no functional changes)

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings