### PR TITLE
fix: Initialize self.rollouts_for_wandb

### DIFF
--- a/environments/mcqa_thinking_env.py
+++ b/environments/mcqa_thinking_env.py
@@ -43,6 +43,7 @@ class MCQAThinkingEnv(BaseEnv):
         super().__init__(config, server_configs, slurm, testing)
         self.percent_correct_buffer = list()
         self.eval_metrics = list()
+        self.rollouts_for_wandb = []
 
     @classmethod
     def config_init(self) -> Tuple[BaseEnvConfig, List[APIServerConfig]]:


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
**Initialize:** `self.rollouts_for_wandb` instance variable in `MCQAThinkingEnv.__init__()` to prevent `AttributeError`

**Problem:** `self.rollouts_for_wandb` is used but never initialized in `__init__` causing `AttributeError` 

**Solution:** Add `self.rollouts_for_wandb = []` in `__init__`

### Related Issues
N/A - Code quality improvement discovered during code review

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (no functional changes)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes