### PR TITLE
fix duplicate code + add safety checks

### DIFF
--- a/atroposlib/utils/best_of_n_selection.py
+++ b/atroposlib/utils/best_of_n_selection.py
@@ -36,9 +36,6 @@ def select_best_index(
         raise ValueError("Primary and secondary score lists must have the same length.")
 
     num_items = len(primary_scores)
-    if num_items == 0:  # Should be caught by the first check, but as a safeguard.
-        raise ValueError("Input score lists cannot be empty.")
-
     best_index = 0
 
     for i in range(1, num_items):

--- a/environments/math_server.py
+++ b/environments/math_server.py
@@ -552,7 +552,10 @@ class MathEnv(BaseEnv):
                     i
                     for i, score in enumerate(to_postprocess["scores"])
                     if score == 1.0
-                ][0]
+                ]
+                if len(pos_idx) == 0:
+                    return None, to_backlog
+                pos_idx = pos_idx[0]
                 neg_idx = [
                     i
                     for i, score in enumerate(to_postprocess["scores"])

--- a/environments/tool_use_interleaved_thinking.py
+++ b/environments/tool_use_interleaved_thinking.py
@@ -252,8 +252,6 @@ class InterleavedInlineEnv(BaseEnv):
             print(f"[DEBUG setup] kept {len(subset)} rows from Dataset")
 
         split = full.train_test_split(test_size=0.02, seed=42)
-
-        split = full.train_test_split(test_size=0.02, seed=42)
         self.train, self.test = split["train"], split["test"]
         self.train = self.train.shuffle(seed=int.from_bytes(os.urandom(2), "big"))
 


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR

---

## 📝 General Information

### Description
Fixed three minor bugs discovered during code review:

1. **tool_use_interleaved_thinking.py (line 254-255)**: Removed duplicate `train_test_split` call - the result of the first call was immediately overwritten by an identical second call.

2. **math_server.py**: Added missing empty-list check for `pos_idx` before indexing with `[0]`. Without this, an `IndexError` is raised when no positive-scored answers exist. This matches the existing guard pattern already in place for `neg_idx` a few lines below.

3. **best_of_n_selection.py**: Removed unreachable redundant emptiness check - the same condition is already caught by the `if not primary_scores` check three lines earlier.

### Related Issues
None - these bugs were discovered during codebase exploration.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] Existing tests still pass