### PR TITLE
Fix/multimodal remove image reencode

### DIFF
--- a/environments/multimodal_dpo/clevr_complex.py
+++ b/environments/multimodal_dpo/clevr_complex.py
@@ -28,39 +28,30 @@ class MultimodalComplexEnv(BaseEnv):
     ) -> Tuple[GameHistory | None, List[Item]]:
         to_score = list()
         to_backlog = list()
+        prompt_tuple, gold_answer, base64_image = item
 
-        # Get the current image if it was stored
-        if hasattr(self, "current_image"):
+        # Extract text content from item
+        user_content = dict(prompt_tuple[0]).get("content", "")
 
-            # Convert PIL image to base64
-            import io
+        # Try to parse if it's JSON
+        if isinstance(user_content, str) and (
+            user_content.startswith("[") or user_content.startswith("{")
+        ):
+            try:
+                parsed = json.loads(user_content)
+                text_content = ""
+                for element in parsed:
+                    if element.get("type") == "text":
+                        text_content = element.get("text", "")
 
-            img_byte_arr = io.BytesIO()
-            self.current_image.save(img_byte_arr, format="PNG")
-            img_byte_arr = img_byte_arr.getvalue()
-            base64_image = base64.b64encode(img_byte_arr).decode("utf-8")
-
-            # Extract text content from item
-            user_content = dict(item[0][0]).get("content", "")
-
-            # Try to parse if it's JSON
-            if isinstance(user_content, str) and (
-                user_content.startswith("[") or user_content.startswith("{")
-            ):
-                try:
-                    parsed = json.loads(user_content)
-                    text_content = ""
-                    for element in parsed:
-                        if element.get("type") == "text":
-                            text_content = element.get("text", "")
-
-                    if not text_content:
-                        text_content = "Please solve this problem and provide your answer as \\boxed{answer}."
-                except Exception:
+                if not text_content:
                     text_content = "Please solve this problem and provide your answer as \\boxed{answer}."
-            else:
-                text_content = user_content
+            except Exception:
+                text_content = "Please solve this problem and provide your answer as \\boxed{answer}."
+        else:
+            text_content = user_content
 
+        if base64_image:
             # Create messages with the new format
             messages = [
                 {
@@ -99,10 +90,10 @@ class MultimodalComplexEnv(BaseEnv):
 
         for i, chat_completion in enumerate(chat_completions.choices):
             messages = (
-                dict(item[0][0]),
+                dict(prompt_tuple[0]),
                 {"role": "assistant", "content": chat_completion.message.content},
             )
-            to_score.append((messages, item[1], base64_image))
+            to_score.append((messages, gold_answer, base64_image))
 
         to_postprocess = await self.score(to_score)
 


### PR DESCRIPTION
## Why was this change needed?
`clevr_cogen_a_train` and `clevr_complex` were re-encoding the same image to base64 twice:
- first in [get_next_item](https://github.com/NousResearch/atropos/blob/7ceed9b6d9a78bdae9691cb246b59d64521fbf8a/atroposlib/envs/base.py#L394-L401),
- then again in [collect_trajectories](https://github.com/NousResearch/atropos/blob/7ceed9b6d9a78bdae9691cb246b59d64521fbf8a/atroposlib/envs/base.py#L328-L378).

This added unnecessary CPU/memory work and relied on `self.current_image` shared state, which is fragile under concurrent workers.

## What changed?
- Removed image re-encoding from `collect_trajectories` in both envs.
- Switched trajectory/message building to use `base64_image` from the input item tuple directly.
- Kept behavior unchanged from the caller perspective, but eliminated redundant allocations and reduced risk of image/item mismatch.