### PR TITLE
fix: align accuracy reward docstring with actual parsing

### DIFF
--- a/atroposlib/envs/reward_fns/accuracy_reward.py
+++ b/atroposlib/envs/reward_fns/accuracy_reward.py
@@ -24,7 +24,6 @@ def _extract_final_answer(text: str) -> str:
 
     Handles formats like:
     - "#### 42" (GSM8K style)
-    - "The answer is 42"
     - "\\boxed{42}"
 
     Returns the extracted answer or the original text if no pattern is found.


### PR DESCRIPTION
The `_extract_final_answer` docstring listed "The answer is 42" as a supported format, but the function only parses GSM8K-style #### ... and LaTeX \\boxed{...} patterns. This mismatch could mislead contributors and cause incorrect assumptions about reward behavior.