### PR TITLE
fix: reuse single tree snapshot in get_state

### DIFF
--- a/atroposlib/envs/server_handling/managed_server.py
+++ b/atroposlib/envs/server_handling/managed_server.py
@@ -494,9 +494,10 @@ class ManagedServer:
                 Dictionary with 'sequences': Dict[str, SequenceNode] and 'tree' alias
         """
         if self.track_tree:
+            sequences_snapshot = self.sequences.copy()
             return {
-                "sequences": self.sequences.copy(),
-                "tree": self.sequences.copy(),  # Alias for compatibility
+                "sequences": sequences_snapshot,
+                "tree": sequences_snapshot,  # Alias for compatibility
             }
         else:
             return {
@@ -607,9 +608,10 @@ class DummyManagedServer:
     def get_state(self) -> Dict[str, Any]:
         """Get the current state of tracked sequences."""
         if self.track_tree:
+            sequences_snapshot = self.sequences.copy()
             return {
-                "sequences": self.sequences.copy(),
-                "tree": self.sequences.copy(),
+                "sequences": sequences_snapshot,
+                "tree": sequences_snapshot,
             }
         else:
             return {"nodes": self.current_nodes.copy()}


### PR DESCRIPTION
In tree mode, `get_state()` was creating two separate dictionary copies for sequences and tree on every call, even though tree is documented as a compatibility alias. This caused unnecessary allocations and made alias semantics inconsistent.