### PR TITLE
Add Graph of Tiered Experts Architecture environment

### DIFF
--- a/environments/community/moe_routing/README.md
+++ b/environments/community/moe_routing/README.md
@@ -1,10 +1,10 @@
 # Graph of Tiered Experts Architecture
 
-Train a language model to act as a routing policy for a Graph of Tiered Experts Architecture built from frozen Qwen3.5 model tiers.
+Train a language model to act as a routing policy for a Graph of Tiered Experts Architecture built from frozen Hermes-series expert tiers.
 
 ## Motivation
 
-Standard MoE trains experts and gates jointly during pre-training — requiring massive compute. This environment instead learns post-hoc routing across frozen same-family model tiers. The experts are pre-trained Qwen3.5 variants at different scales (0.8B to 35B parameters). Only the routing policy learns, from RL reward signals.
+Standard MoE trains experts and gates jointly during pre-training, requiring massive compute. This environment instead learns post-hoc routing across frozen Hermes-series tiers. The experts are role-specialized tiers spanning 3B, 8B, and 70B-class Hermes checkpoints. Only the routing policy learns, from RL reward signals.
 
 The model learns to be a router: given a query and expert descriptions, it selects which experts should handle the request. Reward is based on whether it picked the right experts for the query's intent, whether those experts have relevant capabilities, and whether it chose cost-efficient options.
 
@@ -16,17 +16,17 @@ Query + Expert Descriptions → LM (routing policy) → Expert Selection → Rew
                                     └──────── REINFORCE update ──────────┘
 ```
 
-**7 tiered experts from one model family:**
+**7 tiered experts across the Hermes series:**
 
 | ID | Role | Model | Size | Cost |
 |----|------|-------|------|------|
-| g0 | Triage | Qwen3.5-0.8B | 0.5 GB | 0.1 |
-| g1 | Classifier | Qwen3.5-2B | 1.2 GB | 0.2 |
-| a0 | Synthesizer | Qwen3.5-9B | 5.5 GB | 0.5 |
-| a1 | Challenger | Qwen3.5-9B | 5.5 GB | 0.5 |
-| v0 | Validator | Qwen3.5-27B | 15 GB | 0.8 |
-| b0 | Executor | Qwen3.5-35B | 20 GB | 1.0 |
-| q0 | Quorum | Qwen3.5-9B | 5.5 GB | 0.5 |
+| g0 | Triage | DeepHermes 3 3B tier | 2 GB | 0.1 |
+| g1 | Classifier | DeepHermes 3 3B tier | 2 GB | 0.2 |
+| a0 | Synthesizer | DeepHermes 3 8B tier | 5.5 GB | 0.5 |
+| a1 | Challenger | DeepHermes 3 8B tier | 5.5 GB | 0.5 |
+| v0 | Validator | Hermes 3 70B tier | 40 GB | 0.8 |
+| b0 | Executor | Hermes 3 70B tier | 40 GB | 1.0 |
+| q0 | Quorum | DeepHermes 3 8B tier | 5.5 GB | 0.5 |
 
 ## Reward Function
 
@@ -53,8 +53,8 @@ pip install -r requirements.txt
 ### Run with a local model server
 
 ```bash
-# Start a vLLM or mlx_lm server on port 8378
-mlx_lm.server --model Qwen/Qwen3-8B --port 8378
+# Start a vLLM-compatible server on port 8378
+vllm serve NousResearch/DeepHermes-3-Llama-3-8B-Preview --port 8378
 
 # Run the environment
 python environments/community/moe_routing/moe_routing_env.py serve
@@ -76,7 +76,7 @@ The environment accepts standard Atropos configuration plus:
 
 ## Research Applications
 
-- **Tiered expert graphs**: Study routing across same-family experts at different parameter scales
+- **Tiered expert graphs**: Study routing across Hermes-series expert tiers at different parameter scales
 - **Post-hoc routing**: Train routing policies over frozen pre-trained models
 - **Cost-aware inference**: Learn to balance quality vs. compute cost
 - **Distributed routing**: The learned gate is tiny — could be shared via federated learning across edge nodes

--- a/environments/community/moe_routing/README.md
+++ b/environments/community/moe_routing/README.md
@@ -83,7 +83,7 @@ The environment accepts standard Atropos configuration plus:
 
 ## Generalization
 
-The routing-over-frozen-experts pattern generalizes beyond LLMs. The same reward structure applies to any domain with multiple specialized classifiers and a feedback signal: RF signal detection, medical triage, content moderation, network security. See the [Chameleon concept paper](https://github.com/thomasperry/chameleon) for cross-domain analysis.
+The routing-over-frozen-experts pattern generalizes beyond LLMs. The same reward structure applies to any domain with multiple specialized classifiers and a feedback signal: RF signal detection, medical triage, content moderation, network security.
 
 ## License
 

--- a/environments/community/moe_routing/README.md
+++ b/environments/community/moe_routing/README.md
@@ -79,7 +79,7 @@ The environment accepts standard Atropos configuration plus:
 - **Tiered expert graphs**: Study routing across Hermes-series expert tiers at different parameter scales
 - **Post-hoc routing**: Train routing policies over frozen pre-trained models
 - **Cost-aware inference**: Learn to balance quality vs. compute cost
-- **Distributed routing**: The learned gate is tiny — could be shared via federated learning across edge nodes
+- **Distributed routing**: The learned router is tiny — could be shared via federated learning across edge nodes
 
 ## Generalization
 

--- a/environments/community/moe_routing/README.md
+++ b/environments/community/moe_routing/README.md
@@ -1,22 +1,22 @@
-# MoE Routing Environment
+# Graph of Tiered Experts Architecture
 
-Train a language model to act as a gating network for a heterogeneous Mixture-of-Experts inference mesh.
+Train a language model to act as a routing policy for a Graph of Tiered Experts Architecture built from frozen Qwen3.5 model tiers.
 
 ## Motivation
 
-Standard MoE trains experts and gates jointly during pre-training — requiring massive compute. This environment takes a different approach: **frozen experts, learnable gate**. The experts are pre-trained models at different scales (0.8B to 35B parameters). Only the routing policy learns, from RL reward signals. This makes MoE practical on consumer hardware.
+Standard MoE trains experts and gates jointly during pre-training — requiring massive compute. This environment instead learns post-hoc routing across frozen same-family model tiers. The experts are pre-trained Qwen3.5 variants at different scales (0.8B to 35B parameters). Only the routing policy learns, from RL reward signals.
 
 The model learns to be a router: given a query and expert descriptions, it selects which experts should handle the request. Reward is based on whether it picked the right experts for the query's intent, whether those experts have relevant capabilities, and whether it chose cost-efficient options.
 
 ## Architecture
 
 ```
-Query + Expert Descriptions → LM (gating network) → Expert Selection → Reward
-                                     ↑                                    │
-                                     └──────── REINFORCE update ──────────┘
+Query + Expert Descriptions → LM (routing policy) → Expert Selection → Reward
+                                    ↑                                    │
+                                    └──────── REINFORCE update ──────────┘
 ```
 
-**7 heterogeneous experts:**
+**7 tiered experts from one model family:**
 
 | ID | Role | Model | Size | Cost |
 |----|------|-------|------|------|
@@ -40,7 +40,7 @@ Final score is normalized to [-1, 1].
 
 ## Dataset
 
-120 items generated from 8 query templates x 15 topics. Query templates span intent types: triage, synthesis, challenge, validation, execution, simulation, classification, and research. Topics cover AI/ML domains including MoE, distributed training, RLHF, and inference optimization.
+120 items generated from 8 query templates x 15 topics. Query templates span intent types: triage, synthesis, challenge, validation, execution, simulation, classification, and research. Topics cover AI/ML domains including model scaling, distributed training, RLHF, and inference optimization.
 
 ## Quickstart
 
@@ -76,14 +76,14 @@ The environment accepts standard Atropos configuration plus:
 
 ## Research Applications
 
-- **Heterogeneous MoE**: Study routing across experts of different scales/architectures
+- **Tiered expert graphs**: Study routing across same-family experts at different parameter scales
 - **Post-hoc routing**: Train routing policies over frozen pre-trained models
 - **Cost-aware inference**: Learn to balance quality vs. compute cost
 - **Distributed routing**: The learned gate is tiny — could be shared via federated learning across edge nodes
 
 ## Generalization
 
-The routing-over-frozen-experts pattern generalizes beyond LLMs. The same reward structure applies to any domain with multiple specialized classifiers and a feedback signal: RF signal detection, medical triage, content moderation, network security.
+The routing-over-frozen-experts pattern generalizes beyond LLMs. The same reward structure applies to any domain with multiple specialized classifiers and a feedback signal: RF signal detection, medical triage, content moderation, and network security.
 
 ## License
 

--- a/environments/community/moe_routing/README.md
+++ b/environments/community/moe_routing/README.md
@@ -1,0 +1,90 @@
+# MoE Routing Environment
+
+Train a language model to act as a gating network for a heterogeneous Mixture-of-Experts inference mesh.
+
+## Motivation
+
+Standard MoE trains experts and gates jointly during pre-training — requiring massive compute. This environment takes a different approach: **frozen experts, learnable gate**. The experts are pre-trained models at different scales (0.8B to 35B parameters). Only the routing policy learns, from RL reward signals. This makes MoE practical on consumer hardware.
+
+The model learns to be a router: given a query and expert descriptions, it selects which experts should handle the request. Reward is based on whether it picked the right experts for the query's intent, whether those experts have relevant capabilities, and whether it chose cost-efficient options.
+
+## Architecture
+
+```
+Query + Expert Descriptions → LM (gating network) → Expert Selection → Reward
+                                     ↑                                    │
+                                     └──────── REINFORCE update ──────────┘
+```
+
+**7 heterogeneous experts:**
+
+| ID | Role | Model | Size | Cost |
+|----|------|-------|------|------|
+| g0 | Triage | Qwen3.5-0.8B | 0.5 GB | 0.1 |
+| g1 | Classifier | Qwen3.5-2B | 1.2 GB | 0.2 |
+| a0 | Synthesizer | Qwen3.5-9B | 5.5 GB | 0.5 |
+| a1 | Challenger | Qwen3.5-9B | 5.5 GB | 0.5 |
+| v0 | Validator | Qwen3.5-27B | 15 GB | 0.8 |
+| b0 | Executor | Qwen3.5-35B | 20 GB | 1.0 |
+| q0 | Quorum | Qwen3.5-9B | 5.5 GB | 0.5 |
+
+## Reward Function
+
+Three-component weighted reward:
+
+1. **Ideal Match** (weight: 0.5) — Jaccard similarity between selected experts and known-best experts for the query intent
+2. **Capability Alignment** (weight: 0.3) — Whether selected experts' capabilities match the query intent
+3. **Cost Efficiency** (weight: 0.1) — Preference for smaller/cheaper experts when quality is equal
+
+Final score is normalized to [-1, 1].
+
+## Dataset
+
+120 items generated from 8 query templates x 15 topics. Query templates span intent types: triage, synthesis, challenge, validation, execution, simulation, classification, and research. Topics cover AI/ML domains including MoE, distributed training, RLHF, and inference optimization.
+
+## Quickstart
+
+### Install dependencies
+
+```bash
+pip install -r requirements.txt
+```
+
+### Run with a local model server
+
+```bash
+# Start a vLLM or mlx_lm server on port 8378
+mlx_lm.server --model Qwen/Qwen3-8B --port 8378
+
+# Run the environment
+python environments/community/moe_routing/moe_routing_env.py serve
+```
+
+### Run in process mode (local testing)
+
+```bash
+python environments/community/moe_routing/moe_routing_env.py process --num_trajectories 100
+```
+
+### Custom configuration
+
+The environment accepts standard Atropos configuration plus:
+- `top_k` (int, default=2): Number of experts to select per query
+- `ideal_weight` (float, default=0.5): Weight for ideal expert match
+- `capability_weight` (float, default=0.3): Weight for capability alignment
+- `cost_weight` (float, default=0.1): Weight for cost efficiency
+
+## Research Applications
+
+- **Heterogeneous MoE**: Study routing across experts of different scales/architectures
+- **Post-hoc routing**: Train routing policies over frozen pre-trained models
+- **Cost-aware inference**: Learn to balance quality vs. compute cost
+- **Distributed routing**: The learned gate is tiny — could be shared via federated learning across edge nodes
+
+## Generalization
+
+The routing-over-frozen-experts pattern generalizes beyond LLMs. The same reward structure applies to any domain with multiple specialized classifiers and a feedback signal: RF signal detection, medical triage, content moderation, network security. See the [Chameleon concept paper](https://github.com/thomasperry/chameleon) for cross-domain analysis.
+
+## License
+
+MIT

--- a/environments/community/moe_routing/moe_routing_env.py
+++ b/environments/community/moe_routing/moe_routing_env.py
@@ -1,20 +1,21 @@
 """
-MoE Routing Environment — Atropos RL for Heterogeneous Expert Selection.
+Graph of Tiered Experts Architecture — Atropos RL for Same-Family Expert
+Routing.
 
-Trains a language model to act as a gating network for a heterogeneous
-Mixture-of-Experts inference mesh. The model learns which frozen expert
-handles which query type — purely from reward signals.
+Trains a language model to act as a routing policy for a Graph of Tiered
+Experts Architecture built from frozen Qwen3.5 model tiers. The model learns
+which expert tier handles which query type — purely from reward signals.
 
 Architecture:
   - 7 experts at different scales (0.8B → 35B parameters)
-  - Experts are frozen pre-trained models (no fine-tuning)
+  - Experts are frozen pre-trained Qwen3.5 models (no fine-tuning)
   - Only the routing policy learns, via RL reward
-  - Gate sees: query + expert descriptions
-  - Gate outputs: JSON array of expert IDs (top-k selection)
+  - Router sees: query + expert descriptions
+  - Router outputs: JSON array of expert IDs (top-k selection)
   - Reward: ideal_match + capability_alignment + cost_efficiency
 
-This makes MoE practical on consumer hardware where you can't afford
-to train experts jointly. The gate is tiny — its training could be
+Unlike standard MoE, this environment learns post-hoc routing across frozen
+same-family model tiers. The router is tiny, so its training could be
 distributed via DisTrO across edge nodes.
 
 Author: Thomas Perry
@@ -155,9 +156,9 @@ TOPICS = [
     "distributed training with DisTrO",
     "self-hosted inference on consumer hardware",
     "agent skill acquisition via reinforcement learning",
-    "heterogeneous model routing",
+    "tiered model routing",
     "perimeter-based safety constraints",
-    "post-hoc routing in MoE architectures",
+    "post-hoc routing in tiered expert graphs",
     "federated learning of routing policies",
     "open source vs closed AI development",
     "MLX optimization on Apple Silicon",
@@ -170,8 +171,8 @@ TOPICS = [
 # ─── Config ──────────────────────────────────────────────────
 
 
-class MoERoutingConfig(BaseEnvConfig):
-    """Configuration for the MoE Routing environment."""
+class GraphOfTieredExpertsArchitectureConfig(BaseEnvConfig):
+    """Configuration for the Graph of Tiered Experts Architecture environment."""
 
     top_k: int = Field(default=2, description="Number of experts to select per query")
     cost_weight: float = Field(
@@ -188,25 +189,27 @@ class MoERoutingConfig(BaseEnvConfig):
 # ─── Environment ─────────────────────────────────────────────
 
 
-class MoERoutingEnv(BaseEnv):
+class GraphOfTieredExpertsArchitectureEnv(BaseEnv):
     """
     Trains a language model to route queries to the right experts in a
-    heterogeneous MoE mesh.
+    graph of tiered experts.
 
-    The model acts as a gating network:
+    The model acts as a routing policy:
       Input:  query text + expert descriptions
       Output: JSON array of expert IDs (top-k)
       Reward: weighted combination of ideal match, capability alignment,
               and cost efficiency
 
     This environment demonstrates that routing decisions over frozen experts
-    can be learned via RL — making MoE practical on consumer hardware.
+    can be learned via RL across same-family model tiers.
     """
 
-    name = "moe_routing"
-    env_config_cls = MoERoutingConfig
+    name = "graph_of_tiered_experts_architecture"
+    env_config_cls = GraphOfTieredExpertsArchitectureConfig
 
-    def __init__(self, config: MoERoutingConfig, server_configs, **kwargs):
+    def __init__(
+        self, config: GraphOfTieredExpertsArchitectureConfig, server_configs, **kwargs
+    ):
         super().__init__(config, server_configs, **kwargs)
         self._items: List[Dict] = []
         self._item_idx = 0
@@ -240,7 +243,8 @@ class MoERoutingEnv(BaseEnv):
     def _build_prompt(self, item: Dict) -> List[Dict[str, str]]:
         """Build the routing prompt for the model."""
         system = (
-            "You are a routing controller for a Mixture-of-Experts inference mesh. "
+            "You are a routing controller for a Graph of Tiered Experts "
+            "Architecture. "
             "Select the best experts to handle a given query based on intent, "
             "capabilities, and cost efficiency.\n\n"
             f"Available experts:\n{EXPERT_DESC}\n\n"
@@ -374,14 +378,15 @@ class MoERoutingEnv(BaseEnv):
         if self._episode_count > 0:
             avg = self._reward_sum / self._episode_count
             print(
-                f"[MoE Routing] Episodes: {self._episode_count}, Avg Reward: {avg:.4f}"
+                "[Graph of Tiered Experts] "
+                f"Episodes: {self._episode_count}, Avg Reward: {avg:.4f}"
             )
 
     @classmethod
     def config_init(cls):
         """Default configuration for CLI usage."""
         return (
-            MoERoutingConfig(
+            GraphOfTieredExpertsArchitectureConfig(
                 tokenizer_name="Qwen/Qwen3-8B",
                 group_size=4,
                 max_num_workers=2,
@@ -402,4 +407,4 @@ class MoERoutingEnv(BaseEnv):
 
 
 if __name__ == "__main__":
-    MoERoutingEnv.cli()
+    GraphOfTieredExpertsArchitectureEnv.cli()

--- a/environments/community/moe_routing/moe_routing_env.py
+++ b/environments/community/moe_routing/moe_routing_env.py
@@ -1,0 +1,405 @@
+"""
+MoE Routing Environment — Atropos RL for Heterogeneous Expert Selection.
+
+Trains a language model to act as a gating network for a heterogeneous
+Mixture-of-Experts inference mesh. The model learns which frozen expert
+handles which query type — purely from reward signals.
+
+Architecture:
+  - 7 experts at different scales (0.8B → 35B parameters)
+  - Experts are frozen pre-trained models (no fine-tuning)
+  - Only the routing policy learns, via RL reward
+  - Gate sees: query + expert descriptions
+  - Gate outputs: JSON array of expert IDs (top-k selection)
+  - Reward: ideal_match + capability_alignment + cost_efficiency
+
+This makes MoE practical on consumer hardware where you can't afford
+to train experts jointly. The gate is tiny — its training could be
+distributed via DisTrO across edge nodes.
+
+Author: Thomas Perry
+License: MIT
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+from typing import Any, Dict, List, Optional, Tuple
+
+from pydantic import Field
+
+from atroposlib.envs.base import APIServerConfig, BaseEnv, BaseEnvConfig
+from atroposlib.type_definitions import Item
+
+# ─── Expert Definitions ──────────────────────────────────────
+
+EXPERTS = [
+    {
+        "id": "g0",
+        "name": "triage",
+        "model": "Qwen3.5-0.8B",
+        "size_gb": 0.5,
+        "cost": 0.1,
+        "capabilities": ["triage", "routing", "intent"],
+    },
+    {
+        "id": "g1",
+        "name": "classifier",
+        "model": "Qwen3.5-2B",
+        "size_gb": 1.2,
+        "cost": 0.2,
+        "capabilities": ["classify", "annotate", "mediate"],
+    },
+    {
+        "id": "a0",
+        "name": "synthesizer",
+        "model": "Qwen3.5-9B",
+        "size_gb": 5.5,
+        "cost": 0.5,
+        "capabilities": ["synthesize", "reason", "assemble"],
+    },
+    {
+        "id": "a1",
+        "name": "challenger",
+        "model": "Qwen3.5-9B",
+        "size_gb": 5.5,
+        "cost": 0.5,
+        "capabilities": ["refute", "challenge", "adversarial"],
+    },
+    {
+        "id": "v0",
+        "name": "validator",
+        "model": "Qwen3.5-27B",
+        "size_gb": 15.0,
+        "cost": 0.8,
+        "capabilities": ["validate", "critique", "verify"],
+    },
+    {
+        "id": "b0",
+        "name": "executor",
+        "model": "Qwen3.5-35B",
+        "size_gb": 20.0,
+        "cost": 1.0,
+        "capabilities": ["execute", "distill", "plan"],
+    },
+    {
+        "id": "q0",
+        "name": "quorum",
+        "model": "Qwen3.5-9B",
+        "size_gb": 5.5,
+        "cost": 0.5,
+        "capabilities": ["simulate", "quorum", "generate"],
+    },
+]
+
+EXPERT_IDS = {e["id"] for e in EXPERTS}
+
+EXPERT_DESC = "\n".join(
+    f"- {e['id']} ({e['name']}): {e['model']}, {e['size_gb']}GB, "
+    f"capabilities={e['capabilities']}, cost={e['cost']}"
+    for e in EXPERTS
+)
+
+
+# ─── Query Templates ─────────────────────────────────────────
+
+QUERY_TEMPLATES = [
+    {
+        "intent": "triage",
+        "query": "What kind of question is this: '{topic}'?",
+        "ideal": ["g0", "g1"],
+    },
+    {
+        "intent": "synthesis",
+        "query": "Synthesize a comprehensive analysis of {topic}.",
+        "ideal": ["a0", "v0"],
+    },
+    {
+        "intent": "challenge",
+        "query": "What are the strongest counterarguments to {topic}?",
+        "ideal": ["a1", "v0"],
+    },
+    {
+        "intent": "validation",
+        "query": "Verify whether this claim is accurate: {topic}.",
+        "ideal": ["v0", "g1"],
+    },
+    {
+        "intent": "execution",
+        "query": "Create a step-by-step plan to implement {topic}.",
+        "ideal": ["b0", "a0"],
+    },
+    {
+        "intent": "simulation",
+        "query": "Simulate three possible outcomes of {topic}.",
+        "ideal": ["q0", "a0"],
+    },
+    {
+        "intent": "classify",
+        "query": "Classify {topic} into the most relevant categories.",
+        "ideal": ["g1", "g0"],
+    },
+    {
+        "intent": "research",
+        "query": "Conduct a deep research review on {topic}.",
+        "ideal": ["a0", "v0", "b0"],
+    },
+]
+
+TOPICS = [
+    "transformer attention mechanisms",
+    "mixture of experts scaling laws",
+    "RLHF vs constitutional AI",
+    "distributed training with DisTrO",
+    "self-hosted inference on consumer hardware",
+    "agent skill acquisition via reinforcement learning",
+    "heterogeneous model routing",
+    "perimeter-based safety constraints",
+    "post-hoc routing in MoE architectures",
+    "federated learning of routing policies",
+    "open source vs closed AI development",
+    "MLX optimization on Apple Silicon",
+    "token-level reward attribution",
+    "curriculum learning for language models",
+    "emergent capabilities in small models",
+]
+
+
+# ─── Config ──────────────────────────────────────────────────
+
+
+class MoERoutingConfig(BaseEnvConfig):
+    """Configuration for the MoE Routing environment."""
+
+    top_k: int = Field(default=2, description="Number of experts to select per query")
+    cost_weight: float = Field(
+        default=0.1, description="Weight for cost efficiency in reward"
+    )
+    capability_weight: float = Field(
+        default=0.3, description="Weight for capability match in reward"
+    )
+    ideal_weight: float = Field(
+        default=0.5, description="Weight for ideal expert match in reward"
+    )
+
+
+# ─── Environment ─────────────────────────────────────────────
+
+
+class MoERoutingEnv(BaseEnv):
+    """
+    Trains a language model to route queries to the right experts in a
+    heterogeneous MoE mesh.
+
+    The model acts as a gating network:
+      Input:  query text + expert descriptions
+      Output: JSON array of expert IDs (top-k)
+      Reward: weighted combination of ideal match, capability alignment,
+              and cost efficiency
+
+    This environment demonstrates that routing decisions over frozen experts
+    can be learned via RL — making MoE practical on consumer hardware.
+    """
+
+    name = "moe_routing"
+    env_config_cls = MoERoutingConfig
+
+    def __init__(self, config: MoERoutingConfig, server_configs, **kwargs):
+        super().__init__(config, server_configs, **kwargs)
+        self._items: List[Dict] = []
+        self._item_idx = 0
+        self._episode_count = 0
+        self._reward_sum = 0.0
+
+    async def setup(self):
+        """Generate query items from templates x topics."""
+        for template in QUERY_TEMPLATES:
+            for topic in TOPICS:
+                self._items.append(
+                    {
+                        "intent": template["intent"],
+                        "query": template["query"].format(topic=topic),
+                        "ideal": template["ideal"],
+                        "topic": topic,
+                    }
+                )
+        random.shuffle(self._items)
+        await self.setup_wandb()
+
+    async def get_next_item(self) -> Item:
+        """Cycle through items."""
+        if not self._items:
+            await asyncio.sleep(1)
+            return None
+        item = self._items[self._item_idx % len(self._items)]
+        self._item_idx += 1
+        return item
+
+    def _build_prompt(self, item: Dict) -> List[Dict[str, str]]:
+        """Build the routing prompt for the model."""
+        system = (
+            "You are a routing controller for a Mixture-of-Experts inference mesh. "
+            "Select the best experts to handle a given query based on intent, "
+            "capabilities, and cost efficiency.\n\n"
+            f"Available experts:\n{EXPERT_DESC}\n\n"
+            f"Select exactly {self.config.top_k} experts. "
+            'Respond with ONLY a JSON array of expert IDs, e.g. ["a0", "v0"]. '
+            "No explanation, no markdown, just the JSON array."
+        )
+        return [
+            {"role": "system", "content": system},
+            {"role": "user", "content": f"Route this query:\n\n{item['query']}"},
+        ]
+
+    def _parse_selection(self, text: str) -> List[str]:
+        """Parse model output into expert IDs."""
+        text = text.strip()
+        # Try direct JSON parse
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, list):
+                return [x for x in parsed if isinstance(x, str) and x in EXPERT_IDS]
+        except json.JSONDecodeError:
+            pass
+        # Fallback: extract IDs from text
+        return [
+            w.strip("\"'[].,") for w in text.split() if w.strip("\"'[].,") in EXPERT_IDS
+        ]
+
+    def _score(self, selected: List[str], item: Dict) -> Tuple[float, Dict]:
+        """
+        Score expert selection with three components:
+
+        1. Ideal match (Jaccard similarity with known-best experts)
+        2. Capability match (do selected experts have relevant capabilities?)
+        3. Cost efficiency (prefer cheaper experts when quality is equal)
+
+        Returns (score, breakdown_dict).
+        """
+        if not selected:
+            return -1.0, {"reason": "no_valid_selection"}
+
+        ideal = set(item["ideal"])
+        chosen = set(selected[: self.config.top_k])
+
+        # 1. Ideal match — Jaccard similarity
+        overlap = len(ideal & chosen)
+        union = len(ideal | chosen)
+        ideal_score = overlap / union if union > 0 else 0.0
+
+        # 2. Capability match — does the expert's capability list contain the intent?
+        intent = item["intent"].lower()
+        cap_score = 0.0
+        for eid in chosen:
+            expert = next((e for e in EXPERTS if e["id"] == eid), None)
+            if expert:
+                for cap in expert["capabilities"]:
+                    if cap in intent or intent in cap:
+                        cap_score += 0.5
+        cap_score = min(cap_score, 1.0)
+
+        # 3. Cost efficiency — normalized inverse cost
+        total_cost = sum(
+            next((e["cost"] for e in EXPERTS if e["id"] == eid), 1.0) for eid in chosen
+        )
+        max_cost = sum(
+            sorted([e["cost"] for e in EXPERTS], reverse=True)[: self.config.top_k]
+        )
+        cost_score = 1.0 - (total_cost / max_cost) if max_cost > 0 else 0.5
+
+        # Weighted combination
+        raw = (
+            self.config.ideal_weight * ideal_score
+            + self.config.capability_weight * cap_score
+            + self.config.cost_weight * cost_score
+        )
+        # Normalize to [-1, 1]
+        score = max(-1.0, min(1.0, raw * 2 - 0.5))
+
+        breakdown = {
+            "ideal_score": round(ideal_score, 3),
+            "cap_score": round(cap_score, 3),
+            "cost_score": round(cost_score, 3),
+            "total_cost": round(total_cost, 3),
+            "selected": list(chosen),
+            "ideal": list(ideal),
+            "intent": item["intent"],
+            "final_score": round(score, 3),
+        }
+        return score, breakdown
+
+    async def collect_trajectory(self, item: Item) -> Tuple[Optional[Dict], List[Item]]:
+        """
+        Collect a single routing trajectory:
+        1. Build prompt with query + expert descriptions
+        2. Model generates expert selection (JSON array)
+        3. Score the selection
+        4. Return scored tokens for training
+        """
+        messages = self._build_prompt(item)
+
+        async with self.server.managed_server(tokenizer=self.tokenizer) as managed:
+            completion = await managed.completion(
+                prompt=messages,
+                n=1,
+                max_tokens=64,
+                temperature=0.3,
+            )
+            state = managed.get_state()
+            node = state["nodes"][0]
+
+        # Parse and score
+        generated = (
+            completion.choices[0].text
+            if hasattr(completion.choices[0], "text")
+            else str(completion.choices[0])
+        )
+        selected = self._parse_selection(generated)
+        score, breakdown = self._score(selected, item)
+
+        # Track metrics
+        self._episode_count += 1
+        self._reward_sum += score
+
+        return {
+            "tokens": node.tokens,
+            "masks": node.masked_tokens,
+            "scores": score,
+        }, []
+
+    async def evaluate(self, *args, **kwargs):
+        """Log evaluation metrics."""
+        if self._episode_count > 0:
+            avg = self._reward_sum / self._episode_count
+            print(
+                f"[MoE Routing] Episodes: {self._episode_count}, Avg Reward: {avg:.4f}"
+            )
+
+    @classmethod
+    def config_init(cls):
+        """Default configuration for CLI usage."""
+        return (
+            MoERoutingConfig(
+                tokenizer_name="Qwen/Qwen3-8B",
+                group_size=4,
+                max_num_workers=2,
+                steps_per_eval=50,
+                max_token_length=512,
+                total_steps=1000,
+                top_k=2,
+                use_wandb=True,
+            ),
+            [
+                APIServerConfig(
+                    model_name="Qwen/Qwen3-8B",
+                    base_url="http://127.0.0.1:8378/v1",
+                    api_key="local",
+                )
+            ],
+        )
+
+
+if __name__ == "__main__":
+    MoERoutingEnv.cli()

--- a/environments/community/moe_routing/moe_routing_env.py
+++ b/environments/community/moe_routing/moe_routing_env.py
@@ -1,21 +1,21 @@
 """
-Graph of Tiered Experts Architecture — Atropos RL for Same-Family Expert
+Graph of Tiered Experts Architecture — Atropos RL for Hermes-Series Expert
 Routing.
 
 Trains a language model to act as a routing policy for a Graph of Tiered
-Experts Architecture built from frozen Qwen3.5 model tiers. The model learns
-which expert tier handles which query type — purely from reward signals.
+Experts Architecture built from frozen Hermes-series expert tiers. The model
+learns which expert tier handles which query type purely from reward signals.
 
 Architecture:
-  - 7 experts at different scales (0.8B → 35B parameters)
-  - Experts are frozen pre-trained Qwen3.5 models (no fine-tuning)
+  - 7 experts distributed across Hermes-series 3B, 8B, and 70B tiers
+  - Experts are frozen pre-trained Hermes-series models (no fine-tuning)
   - Only the routing policy learns, via RL reward
   - Router sees: query + expert descriptions
   - Router outputs: JSON array of expert IDs (top-k selection)
   - Reward: ideal_match + capability_alignment + cost_efficiency
 
 Unlike standard MoE, this environment learns post-hoc routing across frozen
-same-family model tiers. The router is tiny, so its training could be
+Hermes-series expert tiers. The router is tiny, so its training could be
 distributed via DisTrO across edge nodes.
 
 Author: Thomas Perry
@@ -40,23 +40,23 @@ EXPERTS = [
     {
         "id": "g0",
         "name": "triage",
-        "model": "Qwen3.5-0.8B",
-        "size_gb": 0.5,
+        "model": "DeepHermes 3 3B tier",
+        "size_gb": 2.0,
         "cost": 0.1,
         "capabilities": ["triage", "routing", "intent"],
     },
     {
         "id": "g1",
         "name": "classifier",
-        "model": "Qwen3.5-2B",
-        "size_gb": 1.2,
+        "model": "DeepHermes 3 3B tier",
+        "size_gb": 2.0,
         "cost": 0.2,
         "capabilities": ["classify", "annotate", "mediate"],
     },
     {
         "id": "a0",
         "name": "synthesizer",
-        "model": "Qwen3.5-9B",
+        "model": "DeepHermes 3 8B tier",
         "size_gb": 5.5,
         "cost": 0.5,
         "capabilities": ["synthesize", "reason", "assemble"],
@@ -64,7 +64,7 @@ EXPERTS = [
     {
         "id": "a1",
         "name": "challenger",
-        "model": "Qwen3.5-9B",
+        "model": "DeepHermes 3 8B tier",
         "size_gb": 5.5,
         "cost": 0.5,
         "capabilities": ["refute", "challenge", "adversarial"],
@@ -72,23 +72,23 @@ EXPERTS = [
     {
         "id": "v0",
         "name": "validator",
-        "model": "Qwen3.5-27B",
-        "size_gb": 15.0,
+        "model": "Hermes 3 70B tier",
+        "size_gb": 40.0,
         "cost": 0.8,
         "capabilities": ["validate", "critique", "verify"],
     },
     {
         "id": "b0",
         "name": "executor",
-        "model": "Qwen3.5-35B",
-        "size_gb": 20.0,
+        "model": "Hermes 3 70B tier",
+        "size_gb": 40.0,
         "cost": 1.0,
         "capabilities": ["execute", "distill", "plan"],
     },
     {
         "id": "q0",
         "name": "quorum",
-        "model": "Qwen3.5-9B",
+        "model": "DeepHermes 3 8B tier",
         "size_gb": 5.5,
         "cost": 0.5,
         "capabilities": ["simulate", "quorum", "generate"],
@@ -201,7 +201,7 @@ class GraphOfTieredExpertsArchitectureEnv(BaseEnv):
               and cost efficiency
 
     This environment demonstrates that routing decisions over frozen experts
-    can be learned via RL across same-family model tiers.
+    can be learned via RL across Hermes-series tiers.
     """
 
     name = "graph_of_tiered_experts_architecture"
@@ -387,7 +387,7 @@ class GraphOfTieredExpertsArchitectureEnv(BaseEnv):
         """Default configuration for CLI usage."""
         return (
             GraphOfTieredExpertsArchitectureConfig(
-                tokenizer_name="Qwen/Qwen3-8B",
+                tokenizer_name="NousResearch/DeepHermes-3-Llama-3-8B-Preview",
                 group_size=4,
                 max_num_workers=2,
                 steps_per_eval=50,
@@ -398,7 +398,7 @@ class GraphOfTieredExpertsArchitectureEnv(BaseEnv):
             ),
             [
                 APIServerConfig(
-                    model_name="Qwen/Qwen3-8B",
+                    model_name="NousResearch/DeepHermes-3-Llama-3-8B-Preview",
                     base_url="http://127.0.0.1:8378/v1",
                     api_key="local",  # pragma: allowlist secret
                 )

--- a/environments/community/moe_routing/moe_routing_env.py
+++ b/environments/community/moe_routing/moe_routing_env.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 import asyncio
 import json
 import random
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from pydantic import Field
 
@@ -395,7 +395,7 @@ class MoERoutingEnv(BaseEnv):
                 APIServerConfig(
                     model_name="Qwen/Qwen3-8B",
                     base_url="http://127.0.0.1:8378/v1",
-                    api_key="local",
+                    api_key="local",  # pragma: allowlist secret
                 )
             ],
         )

--- a/environments/community/moe_routing/requirements.txt
+++ b/environments/community/moe_routing/requirements.txt
@@ -1,0 +1,3 @@
+atroposlib
+wandb
+pydantic


### PR DESCRIPTION
## Graph of Tiered Experts Architecture Environment

Trains a language model to act as a routing policy over frozen Hermes-series expert tiers.

### What it does

- **7 frozen Hermes-series experts** distributed across 3B, 8B, and 70B tiers
- **120 routing scenarios** (8 query templates x 15 topics) covering triage, synthesis, validation, execution, simulation, classification, and research
- **3-component reward**: ideal match (Jaccard similarity, 50%), capability alignment (30%), cost efficiency (10%)
- Expert selection via JSON output, e.g. `["a0", "v0"]`

### Why it matters

Standard MoE trains experts and gates jointly inside a single model architecture. This environment instead learns post-hoc routing across frozen Hermes-series tiers, making the routing problem trainable without retraining the experts themselves.

### Architecture

| Expert | Tier | Role |
|--------|------|------|
| g0 | DeepHermes 3 3B | Triage |
| g1 | DeepHermes 3 3B | Classification |
| a0 | DeepHermes 3 8B | Synthesis |
| a1 | DeepHermes 3 8B | Adversarial challenge |
| v0 | Hermes 3 70B | Validation |
| b0 | Hermes 3 70B | Execution |
| q0 | DeepHermes 3 8B | Quorum simulation |

### Quick start

```bash
vllm serve NousResearch/DeepHermes-3-Llama-3-8B-Preview --port 8378
python environments/community/moe_routing/moe_routing_env.py serve --port 8332
python environments/community/moe_routing/moe_routing_env.py process --num_trajectories 100
```

### Research applications

- Graph of Tiered Experts Architecture routing
- LM-as-router via RL
- Cost-aware expert selection
- Federated routing policy optimization via Psyche/DisTrO
