### PR TITLE
feat: online reward normalization (Welford’s algorithm)

### DIFF
--- a/atroposlib/envs/base.py
+++ b/atroposlib/envs/base.py
@@ -211,6 +211,23 @@ class BaseEnvConfig(BaseModel):
         "no thinking prompt is injected. Use HERMES_REASONING_PROMPT from "
         "eval_helpers for the standard Hermes reasoning prompt.",
     )
+    reward_normalization: str = Field(
+        default="none",
+        description="Reward normalization mode. 'none' = disabled (default), "
+        "'zscore' = z-score normalization, 'minmax' = min-max to [0,1]. "
+        "Uses Welford's online algorithm for running statistics.",
+    )
+    reward_clip: float = Field(
+        default=5.0,
+        description="Maximum absolute reward value after normalization. "
+        "Only applies when reward_normalization is not 'none'. "
+        "Set to 0 to disable clipping.",
+    )
+    reward_normalization_warmup: int = Field(
+        default=10,
+        description="Number of scored batches to observe before activating "
+        "reward normalization. During warmup, raw scores are used.",
+    )
 
 
 class BaseEnv(ABC):
@@ -262,6 +279,17 @@ class BaseEnv(ABC):
         self.max_token_len = -1
         self.tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_name)
         self.completion_lengths = []
+        # Initialize reward normalizer (opt-in via config)
+        if config.reward_normalization != "none":
+            from atroposlib.envs.reward_normalization import RewardNormalizer
+
+            self.reward_normalizer = RewardNormalizer(
+                mode=config.reward_normalization,
+                clip=config.reward_clip,
+                warmup=config.reward_normalization_warmup,
+            )
+        else:
+            self.reward_normalizer = None
         self.max_num_workers = config.max_num_workers
         if self.max_num_workers == -1:
             self.max_num_workers = config.max_num_workers_per_node * len(
@@ -674,6 +702,9 @@ class BaseEnv(ABC):
             wandb_metrics["train/completion_lengths_p95"] = (
                 np.array(self.completion_lengths) > (0.95 * self.max_token_len)
             ).mean()
+        # Log reward normalization metrics if active
+        if self.reward_normalizer is not None:
+            wandb_metrics.update(self.reward_normalizer.metrics_dict())
         wandb_metrics = await self.create_rollout_table(wandb_metrics)
         wandb_metrics = self.perf_stats(wandb_metrics)
         self.rollouts_for_wandb = []
@@ -891,6 +922,16 @@ class BaseEnv(ABC):
             ):
                 logger.warning("Scores are the same in a group, skipping...")
                 continue
+
+            # Apply reward normalization if enabled (opt-in via config)
+            if self.reward_normalizer is not None:
+                group["scores"] = self.reward_normalizer.normalize(group["scores"])
+                # Re-check after normalization: if all scores collapsed, skip
+                if len(set(group["scores"])) == 1:
+                    logger.debug(
+                        "Scores collapsed to same value after normalization, skipping"
+                    )
+                    continue
 
             group.setdefault("ref_logprobs", None)
             group.setdefault("overrides", None)

--- a/atroposlib/envs/reward_normalization.py
+++ b/atroposlib/envs/reward_normalization.py
@@ -1,0 +1,267 @@
+"""
+Online reward normalization for multi-environment RL training stability.
+
+Implements Welford's online algorithm for running mean/variance computation,
+enabling z-score and min-max normalization of reward signals without needing
+to store all historical values.
+
+This is critical for multi-environment training where different environments
+produce rewards on different scales (e.g., GSM8K gives {-1, 1} while
+tool-use environments give continuous [0, 1] scores).
+
+Usage:
+    normalizer = RewardNormalizer(mode="zscore", clip=5.0)
+
+    # During training loop
+    scores = [0.5, -0.3, 0.8, 1.0]
+    normalized = normalizer.normalize(scores)
+
+    # Checkpointing
+    state = normalizer.state_dict()
+    normalizer.load_state_dict(state)
+"""
+
+import logging
+import math
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+class WelfordAccumulator:
+    """
+    Welford's online algorithm for computing running mean and variance.
+
+    Numerically stable single-pass algorithm that avoids catastrophic
+    cancellation. Maintains count, mean, and M2 (sum of squared deviations)
+    to compute variance on demand.
+
+    Reference: Welford, B. P. (1962). "Note on a method for calculating
+    corrected sums of squares and products". Technometrics. 4(3): 419-420.
+    """
+
+    def __init__(self):
+        self.count: int = 0
+        self.mean: float = 0.0
+        self._m2: float = 0.0
+        self._min: float = float("inf")
+        self._max: float = float("-inf")
+
+    def update(self, value: float) -> None:
+        """Update running statistics with a new value."""
+        self.count += 1
+        delta = value - self.mean
+        self.mean += delta / self.count
+        delta2 = value - self.mean
+        self._m2 += delta * delta2
+        self._min = min(self._min, value)
+        self._max = max(self._max, value)
+
+    def update_batch(self, values: List[float]) -> None:
+        """Update running statistics with a batch of values."""
+        for v in values:
+            self.update(v)
+
+    @property
+    def variance(self) -> float:
+        """Population variance of all observed values."""
+        if self.count < 2:
+            return 0.0
+        return self._m2 / self.count
+
+    @property
+    def std(self) -> float:
+        """Population standard deviation of all observed values."""
+        return math.sqrt(self.variance)
+
+    @property
+    def min_val(self) -> float:
+        """Minimum observed value."""
+        return self._min if self.count > 0 else 0.0
+
+    @property
+    def max_val(self) -> float:
+        """Maximum observed value."""
+        return self._max if self.count > 0 else 0.0
+
+    def state_dict(self) -> Dict[str, Any]:
+        """Serialize state for checkpointing."""
+        return {
+            "count": self.count,
+            "mean": self.mean,
+            "m2": self._m2,
+            "min": self._min,
+            "max": self._max,
+        }
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        """Restore state from checkpoint."""
+        self.count = state["count"]
+        self.mean = state["mean"]
+        self._m2 = state["m2"]
+        self._min = state["min"]
+        self._max = state["max"]
+
+
+class RewardNormalizer:
+    """
+    Reward normalization for stable multi-environment RL training.
+
+    Supports two normalization modes:
+    - "zscore": Standardize to zero mean, unit variance using running stats
+    - "minmax": Scale to [0, 1] range using observed min/max
+
+    Both modes use Welford's online algorithm so no historical data storage
+    is required. Optional reward clipping prevents extreme values from
+    destabilizing training.
+
+    Args:
+        mode: Normalization mode. One of "zscore", "minmax", or "none".
+        clip: Maximum absolute value after normalization. Set to 0 or None
+              to disable clipping. Default: 5.0.
+        warmup: Minimum number of samples before normalization activates.
+                During warmup, raw scores are returned (optionally clipped).
+                Default: 10.
+        eps: Small constant for numerical stability in division. Default: 1e-8.
+    """
+
+    VALID_MODES = {"zscore", "minmax", "none"}
+
+    def __init__(
+        self,
+        mode: str = "zscore",
+        clip: Optional[float] = 5.0,
+        warmup: int = 10,
+        eps: float = 1e-8,
+    ):
+        if mode not in self.VALID_MODES:
+            raise ValueError(
+                f"Invalid normalization mode '{mode}'. "
+                f"Must be one of: {self.VALID_MODES}"
+            )
+
+        self.mode = mode
+        self.clip = clip if clip and clip > 0 else None
+        self.warmup = max(0, warmup)
+        self.eps = eps
+        self._accumulator = WelfordAccumulator()
+
+    @property
+    def count(self) -> int:
+        """Number of samples observed."""
+        return self._accumulator.count
+
+    @property
+    def mean(self) -> float:
+        """Running mean of observed values."""
+        return self._accumulator.mean
+
+    @property
+    def std(self) -> float:
+        """Running standard deviation of observed values."""
+        return self._accumulator.std
+
+    @property
+    def is_warmed_up(self) -> bool:
+        """Whether enough samples have been observed for normalization."""
+        return self._accumulator.count >= self.warmup
+
+    def normalize(self, scores: List[float]) -> List[float]:
+        """
+        Normalize a batch of reward scores.
+
+        Updates running statistics with the new scores, then applies
+        normalization. During warmup, raw scores are returned (with
+        optional clipping).
+
+        Args:
+            scores: Raw reward scores to normalize.
+
+        Returns:
+            Normalized (and optionally clipped) scores.
+        """
+        if not scores:
+            return []
+
+        if self.mode == "none":
+            return list(scores)
+
+        # Update running statistics
+        self._accumulator.update_batch(scores)
+
+        # During warmup, return raw scores (optionally clipped)
+        if not self.is_warmed_up:
+            logger.debug(
+                "Reward normalizer warmup: %d/%d samples",
+                self._accumulator.count,
+                self.warmup,
+            )
+            return self._clip(list(scores))
+
+        # Apply normalization
+        if self.mode == "zscore":
+            normalized = self._zscore(scores)
+        elif self.mode == "minmax":
+            normalized = self._minmax(scores)
+        else:
+            normalized = list(scores)
+
+        return self._clip(normalized)
+
+    def _zscore(self, scores: List[float]) -> List[float]:
+        """Z-score normalize: (x - mean) / std."""
+        mean = self._accumulator.mean
+        std = self._accumulator.std
+        if std < self.eps:
+            # All values nearly identical -- return zeros
+            return [0.0] * len(scores)
+        return [(s - mean) / (std + self.eps) for s in scores]
+
+    def _minmax(self, scores: List[float]) -> List[float]:
+        """Min-max normalize to [0, 1] range."""
+        min_val = self._accumulator.min_val
+        max_val = self._accumulator.max_val
+        range_val = max_val - min_val
+        if range_val < self.eps:
+            return [0.5] * len(scores)
+        return [(s - min_val) / (range_val + self.eps) for s in scores]
+
+    def _clip(self, scores: List[float]) -> List[float]:
+        """Clip scores to [-clip, clip] range."""
+        if self.clip is None:
+            return scores
+        return [max(-self.clip, min(self.clip, s)) for s in scores]
+
+    def metrics_dict(self) -> Dict[str, float]:
+        """
+        Return current normalization statistics for WandB logging.
+
+        Returns:
+            Dictionary with keys suitable for wandb.log().
+        """
+        metrics = {
+            "reward_norm/count": float(self._accumulator.count),
+            "reward_norm/mean": self._accumulator.mean,
+            "reward_norm/std": self._accumulator.std,
+            "reward_norm/min": self._accumulator.min_val,
+            "reward_norm/max": self._accumulator.max_val,
+        }
+        return metrics
+
+    def state_dict(self) -> Dict[str, Any]:
+        """Serialize full state for checkpointing."""
+        return {
+            "mode": self.mode,
+            "clip": self.clip,
+            "warmup": self.warmup,
+            "eps": self.eps,
+            "accumulator": self._accumulator.state_dict(),
+        }
+
+    def load_state_dict(self, state: Dict[str, Any]) -> None:
+        """Restore state from checkpoint."""
+        self.mode = state["mode"]
+        self.clip = state["clip"]
+        self.warmup = state["warmup"]
+        self.eps = state["eps"]
+        self._accumulator.load_state_dict(state["accumulator"])

--- a/atroposlib/tests/test_reward_normalization.py
+++ b/atroposlib/tests/test_reward_normalization.py
@@ -12,7 +12,7 @@ Tests cover:
 """
 
 import math
-from typing import List
+
 
 import numpy as np
 import pytest

--- a/atroposlib/tests/test_reward_normalization.py
+++ b/atroposlib/tests/test_reward_normalization.py
@@ -1,0 +1,252 @@
+"""
+Tests for RewardNormalizer -- online reward normalization with Welford's algorithm.
+
+Tests cover:
+- Welford's accumulator numerical accuracy vs numpy
+- Z-score normalization
+- Min-max normalization
+- Clipping behavior
+- Warmup period
+- State save/load roundtrip
+- Edge cases (empty input, constant values, mode validation)
+"""
+
+import math
+from typing import List
+
+import numpy as np
+import pytest
+
+from atroposlib.envs.reward_normalization import RewardNormalizer, WelfordAccumulator
+
+
+# ---------------------------------------------------------------------------
+# WelfordAccumulator tests
+# ---------------------------------------------------------------------------
+
+
+class TestWelfordAccumulator:
+    def test_single_value(self):
+        acc = WelfordAccumulator()
+        acc.update(5.0)
+        assert acc.count == 1
+        assert math.isclose(acc.mean, 5.0)
+        assert math.isclose(acc.variance, 0.0)
+
+    def test_matches_numpy(self):
+        """Welford's running stats should match numpy's batch computation."""
+        np.random.seed(42)
+        values = np.random.randn(1000).tolist()
+
+        acc = WelfordAccumulator()
+        acc.update_batch(values)
+
+        expected_mean = np.mean(values)
+        expected_var = np.var(values)  # population variance
+
+        assert math.isclose(acc.mean, expected_mean, rel_tol=1e-9)
+        assert math.isclose(acc.variance, expected_var, rel_tol=1e-6)
+
+    def test_min_max_tracking(self):
+        acc = WelfordAccumulator()
+        acc.update_batch([3.0, 1.0, 4.0, 1.0, 5.0, 9.0, 2.0, 6.0])
+        assert math.isclose(acc.min_val, 1.0)
+        assert math.isclose(acc.max_val, 9.0)
+
+    def test_state_roundtrip(self):
+        acc = WelfordAccumulator()
+        acc.update_batch([1.0, 2.0, 3.0, 4.0, 5.0])
+        state = acc.state_dict()
+
+        acc2 = WelfordAccumulator()
+        acc2.load_state_dict(state)
+
+        assert acc2.count == acc.count
+        assert math.isclose(acc2.mean, acc.mean)
+        assert math.isclose(acc2.variance, acc.variance)
+        assert math.isclose(acc2.min_val, acc.min_val)
+        assert math.isclose(acc2.max_val, acc.max_val)
+
+    def test_empty_accumulator(self):
+        acc = WelfordAccumulator()
+        assert acc.count == 0
+        assert math.isclose(acc.mean, 0.0)
+        assert math.isclose(acc.variance, 0.0)
+        assert math.isclose(acc.std, 0.0)
+
+
+# ---------------------------------------------------------------------------
+# RewardNormalizer z-score tests
+# ---------------------------------------------------------------------------
+
+
+class TestZScoreNormalization:
+    def test_zscore_centers_around_zero(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=None, warmup=0)
+        # Feed enough data to establish stats
+        normalizer.normalize([1.0, 2.0, 3.0, 4.0, 5.0] * 10)
+        # Now normalize a new batch
+        result = normalizer.normalize([3.0])  # mean should be ~3.0
+        assert abs(result[0]) < 0.1  # Should be near 0
+
+    def test_zscore_output_scale(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=None, warmup=0)
+        # Standard normal-ish data
+        np.random.seed(42)
+        data = np.random.randn(500).tolist()
+        normalizer.normalize(data)
+
+        # Normalize the same data again
+        result = normalizer.normalize(data)
+        # After normalization, std should be approximately 1.0
+        result_std = np.std(result)
+        assert 0.8 < result_std < 1.2
+
+    def test_zscore_constant_values(self):
+        """Constant values should normalize to 0."""
+        normalizer = RewardNormalizer(mode="zscore", clip=None, warmup=0)
+        result = normalizer.normalize([5.0, 5.0, 5.0, 5.0, 5.0])
+        assert all(math.isclose(s, 0.0) for s in result)
+
+
+# ---------------------------------------------------------------------------
+# RewardNormalizer min-max tests
+# ---------------------------------------------------------------------------
+
+
+class TestMinMaxNormalization:
+    def test_minmax_scales_to_unit_range(self):
+        normalizer = RewardNormalizer(mode="minmax", clip=None, warmup=0)
+        normalizer.normalize([0.0, 10.0])  # Establish min=0, max=10
+        result = normalizer.normalize([0.0, 5.0, 10.0])
+        assert math.isclose(result[0], 0.0, abs_tol=1e-6)
+        assert math.isclose(result[1], 0.5, abs_tol=1e-3)
+        assert math.isclose(result[2], 1.0, abs_tol=1e-6)
+
+    def test_minmax_constant_returns_half(self):
+        normalizer = RewardNormalizer(mode="minmax", clip=None, warmup=0)
+        result = normalizer.normalize([3.0, 3.0, 3.0])
+        assert all(math.isclose(s, 0.5) for s in result)
+
+
+# ---------------------------------------------------------------------------
+# Clipping tests
+# ---------------------------------------------------------------------------
+
+
+class TestClipping:
+    def test_clip_bounds(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=2.0, warmup=0)
+        # Feed data with a big outlier
+        normalizer.normalize([0.0] * 100)
+        result = normalizer.normalize([1000.0])
+        assert result[0] <= 2.0
+
+    def test_no_clip_when_disabled(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=None, warmup=0)
+        normalizer.normalize([0.0] * 100)
+        result = normalizer.normalize([1000.0])
+        assert result[0] > 2.0  # Should NOT be clipped
+
+    def test_negative_clip_disabled(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=-1.0, warmup=0)
+        assert normalizer.clip is None
+
+
+# ---------------------------------------------------------------------------
+# Warmup tests
+# ---------------------------------------------------------------------------
+
+
+class TestWarmup:
+    def test_warmup_returns_raw(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=None, warmup=10)
+        # During warmup, should return raw scores
+        result = normalizer.normalize([5.0, 10.0])
+        assert math.isclose(result[0], 5.0)
+        assert math.isclose(result[1], 10.0)
+
+    def test_warmup_transition(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=None, warmup=5)
+        # Feed 3 values (under warmup)
+        r1 = normalizer.normalize([1.0, 2.0, 3.0])
+        assert not normalizer.is_warmed_up
+        # Raw values during warmup
+        assert math.isclose(r1[0], 1.0)
+
+        # Feed 3 more (now at 6, above warmup)
+        r2 = normalizer.normalize([4.0, 5.0, 6.0])
+        assert normalizer.is_warmed_up
+        # Should be normalized now (not raw)
+        assert not math.isclose(r2[0], 4.0)
+
+
+# ---------------------------------------------------------------------------
+# State persistence tests
+# ---------------------------------------------------------------------------
+
+
+class TestStatePersistence:
+    def test_save_load_roundtrip(self):
+        normalizer = RewardNormalizer(mode="zscore", clip=3.0, warmup=5)
+        normalizer.normalize([1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0])
+
+        state = normalizer.state_dict()
+
+        normalizer2 = RewardNormalizer()
+        normalizer2.load_state_dict(state)
+
+        assert normalizer2.mode == "zscore"
+        assert normalizer2.clip == 3.0
+        assert normalizer2.warmup == 5
+        assert normalizer2.count == normalizer.count
+        assert math.isclose(normalizer2.mean, normalizer.mean)
+        assert math.isclose(normalizer2.std, normalizer.std)
+
+    def test_loaded_normalizer_continues(self):
+        """A loaded normalizer should produce same results as the original."""
+        normalizer = RewardNormalizer(mode="zscore", clip=5.0, warmup=0)
+        normalizer.normalize([1.0, 2.0, 3.0, 4.0, 5.0] * 10)
+        state = normalizer.state_dict()
+
+        normalizer2 = RewardNormalizer()
+        normalizer2.load_state_dict(state)
+
+        test_data = [2.5, 3.5, 4.5]
+        r1 = normalizer.normalize(test_data)
+        r2 = normalizer2.normalize(test_data)
+
+        # Results won't be identical because normalize also updates stats,
+        # but they should be very close for the first call after loading
+        for a, b in zip(r1, r2):
+            assert math.isclose(a, b, rel_tol=1e-3)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_empty_input(self):
+        normalizer = RewardNormalizer(mode="zscore")
+        assert normalizer.normalize([]) == []
+
+    def test_none_mode_passthrough(self):
+        normalizer = RewardNormalizer(mode="none")
+        scores = [1.0, 2.0, 3.0]
+        assert normalizer.normalize(scores) == scores
+
+    def test_invalid_mode_raises(self):
+        with pytest.raises(ValueError, match="Invalid normalization mode"):
+            RewardNormalizer(mode="invalid")
+
+    def test_metrics_dict_keys(self):
+        normalizer = RewardNormalizer(mode="zscore", warmup=0)
+        normalizer.normalize([1.0, 2.0, 3.0])
+        metrics = normalizer.metrics_dict()
+        assert "reward_norm/count" in metrics
+        assert "reward_norm/mean" in metrics
+        assert "reward_norm/std" in metrics
+        assert "reward_norm/min" in metrics
+        assert "reward_norm/max" in metrics

--- a/atroposlib/tests/test_reward_normalization.py
+++ b/atroposlib/tests/test_reward_normalization.py
@@ -13,12 +13,10 @@ Tests cover:
 
 import math
 
-
 import numpy as np
 import pytest
 
 from atroposlib.envs.reward_normalization import RewardNormalizer, WelfordAccumulator
-
 
 # ---------------------------------------------------------------------------
 # WelfordAccumulator tests


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
Added an online reward normalizer to `BaseEnv` to keep training stable as rewards shift. I used **Welford’s Online Algorithm** for the running Z-score calculation to keep it O(1) in memory and avoid storing large reward histories.

I included a configurable `warmup_steps` phase so the distribution doesn't start shifting until the mean/std estimates have statistically stabilized. This should fix the gradient explosion issues often seen in early RL training stages.

### Related Issues
- Part of #431  (RL Infrastructure Enhancements)
- Depends on #426 

### Type of Change
- [x] New feature (non-breaking change which adds functionality)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes (21/21 verified)
- [x] Docstrings added for all new public classes / functions
- [x] If .env vars required, did you add it to the .env.example in repo root? (N/A)
