### PR TITLE
docs: fix GitHub Flow link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We welcome any type of contribution, not just code. You can help with:
 We use GitHub to host the code, track issues and feature requests, and accept pull requests.
 
 ## We Use GitHub Flow
-We follow the [GitHub Flow](https://docs.github.com) development workflow. All code changes happen through Pull Requests.
+We follow the [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow) development workflow. All code changes happen through Pull Requests.
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary

`CONTRIBUTING.md` references the [GitHub Flow](https://docs.github.com) workflow but the link points to the GitHub docs root rather than the actual GitHub Flow guide. This updates the URL to point to the correct page.

## Change

```diff
-We follow the [GitHub Flow](https://docs.github.com) development workflow.
+We follow the [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow) development workflow.
```

## Why

New contributors reading CONTRIBUTING.md expect the link to take them to the workflow being referenced. Landing on the docs homepage instead is a minor but confusing dead end.