### PR TITLE
fix: GSM8K environment hardening for ROLL integration

### DIFF
--- a/environments/gsm8k_server.py
+++ b/environments/gsm8k_server.py
@@ -355,8 +355,8 @@ class GSM8kEnv(BaseEnv):
                         percentage_of_range = min(percentage_of_range, 1.0)
                         # Apply linear penalty scaling from 1.0 down to 0.0
                         scores["scores"].append(1.0 - percentage_of_range)
-            
-            # CRITICAL: We comment out the 'all the same' discard filter to allow GRPO 
+
+            # CRITICAL: We comment out the 'all the same' discard filter to allow GRPO
             # to learn from relative process-rewards provided in the ROLL bridge.
             # if all([scores["scores"][0] == score for score in scores["scores"]]):
             #     return None  # If all the same, we return None

--- a/environments/gsm8k_server.py
+++ b/environments/gsm8k_server.py
@@ -1,3 +1,4 @@
+import asyncio
 import random
 import time
 from typing import Dict, List, Optional, Tuple, TypedDict, Union
@@ -5,7 +6,6 @@ from typing import Dict, List, Optional, Tuple, TypedDict, Union
 from datasets import load_dataset
 from latex2sympy2_extended import NormalizationConfig
 from math_verify import LatexExtractionConfig, parse, verify
-from tqdm.asyncio import tqdm_asyncio
 
 from atroposlib.envs.base import (
     APIServerConfig,
@@ -140,6 +140,7 @@ class GSM8kEnv(BaseEnv):
             "\\boxed{" + answer + "}",
             extraction_mode="first_match",
             extraction_config=[LatexExtractionConfig()],
+            parsing_timeout=None,
         )
 
         # Parse model answer
@@ -156,10 +157,11 @@ class GSM8kEnv(BaseEnv):
                         units=True,
                     ),
                     boxed_match_priority=0,
-                    try_extract_without_anchor=False,
+                    try_extract_without_anchor=True,
                 )
             ],
             extraction_mode="first_match",
+            parsing_timeout=None,
         )
 
         score = 1 if verify(answer_parsed, gold_parsed) else 0
@@ -194,7 +196,7 @@ class GSM8kEnv(BaseEnv):
             eval_tasks.append(
                 self.rollout_and_score_eval(item["question"], item["gold_answer"])
             )
-        results = await tqdm_asyncio.gather(*eval_tasks)
+        results = await asyncio.gather(*eval_tasks)
 
         # Extract scores and samples
         scores = [result["score"] for result in results]
@@ -276,6 +278,7 @@ class GSM8kEnv(BaseEnv):
             rollout_group_data[0]["gold_answer"],
             extraction_mode="first_match",
             extraction_config=[LatexExtractionConfig()],
+            parsing_timeout=None,
         )
         if len(gold_parsed) != 0:
             # We require the answer to be provided in correct latex (no malformed operators)
@@ -296,13 +299,14 @@ class GSM8kEnv(BaseEnv):
                             ),
                             # Ensures that boxed is tried first
                             boxed_match_priority=0,
-                            try_extract_without_anchor=False,
+                            try_extract_without_anchor=True,
                         )
                     ],
                     extraction_mode="first_match",
+                    parsing_timeout=None,
                 )
                 # Reward 1 if the content is the same as the ground truth, 0 otherwise
-                reward = verify(answer_parsed, gold_parsed)
+                reward = 1.0 if verify(answer_parsed, gold_parsed) else 0.0
 
                 tokens = item["tokens"]
                 masks = item["masks"]
@@ -351,8 +355,11 @@ class GSM8kEnv(BaseEnv):
                         percentage_of_range = min(percentage_of_range, 1.0)
                         # Apply linear penalty scaling from 1.0 down to 0.0
                         scores["scores"].append(1.0 - percentage_of_range)
-            if all([scores["scores"][0] == score for score in scores["scores"]]):
-                return None  # If all the same, we return None
+            
+            # CRITICAL: We comment out the 'all the same' discard filter to allow GRPO 
+            # to learn from relative process-rewards provided in the ROLL bridge.
+            # if all([scores["scores"][0] == score for score in scores["scores"]]):
+            #     return None  # If all the same, we return None
             return scores
         else:
             # If the gold solution is not parseable, we return None


### PR DESCRIPTION
## PR Type
- [x] RL Environment PR - Complete Environment Snapshot & Zero-Training sections
- [ ] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR enhances the `gsm8k_server` environment to support stable **Agentic Reasoning (GRPO)** training. These changes resolve critical bottlenecks encountered during integration with the **ROLL framework ( [PR](https://github.com/alibaba/ROLL/pull/426) )**, specifically regarding distributed stability, parsing robustness for long-thinking trajectories, and the prevention of "Zero-Reward Stalemates."

### Related Issues
- **Associated Integration**: This PR provides the environment-side support for the ROLL integration done here: [alibaba/ROLL/pull/426](https://github.com/alibaba/ROLL/pull/426)
- **Problem Solved**: Addresses early-stage training data starvation in reasoning-centric RL.

### Summary of File Changes (`environments/gsm8k_server.py`)
1.  **Stalemate Filter Relaxation**: Commented out the identical-score discard filter. This allows external trainers to receive groups where all samples have binary 0 rewards, enabling learning from process-based signals (like thinking tokens) instead of silently dropping the batch.
2.  **Extraction Robustness**: Enabled `try_extract_without_anchor=True` and added `parsing_timeout=None` for all extraction calls. This is required for complex Chain-of-Thought (CoT) trajectories that are often "chatty" or exceptionally long.
3.  **Ray Worker Safety**: Replaced `tqdm_asyncio` with native `asyncio.gather` for rollout evaluation. This eliminates the worker lock-contention/deadlocks seen when Ray's log redirection conflicts with `tqdm` signal handlers.
4.  **Reward Normalization**: Explicitly cast verification results to `1.0`/`0.0` to ensure float consistency across distributed workers.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code refactor (no functional changes)

---


### **Examples of Scoring**

**1. Good Example (Score 1.0):**
> *Input*: "What is 2+2?"
> *Model Output*: "<think> 2+2 is a basic addition. 2 plus 2 equals 4. </think> The answer is \boxed{4}"
> *Result*: **1.0**. (Extraction anchor relaxed to handle the reasoning prefix).

**2. Bad Example (Score 0.0 - Kept for Signal):**
> *Input*: "What is 2+2?"
> *Model Output*: "<think> Let me think... 2 plus 2... maybe it is 5? </think> The answer is \boxed{5}"
> *Result*: **0.0**. (**NOT** discarded; allows external frameworks to reward formatting/deliberation tokens).

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] I have commented my code (specifically the CRITICAL Stalemate filter)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally 
