### PR TITLE
fix(api): use query param for GET /status-env instead of JSON body

### DIFF
--- a/atroposlib/api/README.md
+++ b/atroposlib/api/README.md
@@ -119,7 +119,7 @@ The API documentation (Swagger UI) will be available at `http://<your-server-ip>
     * **Response:** `{"status": "success"}` or `{"status": "failure", "error": ...}`
 * `GET /status-env`
     * **Description:** Called by a Rollout Handler to get general status plus its calculated sampling weight relative to other connected environments.
-    * **Query Parameter:** Requires `env: EnvIdentifier` model (e.g., `?env_id=0` - actual implementation might differ slightly, check FastAPI docs for query parameter models). **Note:** The code shows `env: EnvIdentifier` as a body parameter for a GET request, which is non-standard. This might need adjustment or testing. Assuming it works via query or a POST instead.
+    * **Query Parameter:** `env_id` (integer), e.g. `GET /status-env?env_id=0`.
     * **Response:** `{"current_step": <step>, "queue_size": <size>, "env_weight": <calculated_weight_float>}`
 
 ### Data Handling

--- a/atroposlib/api/env_interaction.md
+++ b/atroposlib/api/env_interaction.md
@@ -40,7 +40,7 @@ sequenceDiagram
 
         %% --- Periodic Queue Size Check (Pause/Resume Logic) ---
         Note over RH: Checking API queue status to decide pause/resume state.
-        RH->>API: GET /status-env (using stored env_id)
+        RH->>API: GET /status-env?env_id=... (using stored env_id)
         activate API
         API-->>RH: Response {"current_step": T_current, "queue_size": Q, "env_weight": W}
         deactivate API

--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -469,7 +469,7 @@ async def get_status():
 
 
 @app.get("/status-env")
-async def get_status_env(env: EnvIdentifier):
+async def get_status_env(env_id: int):
     total = sum(
         [
             x["max_context_len"] * max(0.0, x["weight"])
@@ -477,10 +477,10 @@ async def get_status_env(env: EnvIdentifier):
             if x["connected"]
         ]
     )
-    env_group_size = app.state.envs[env.env_id]["group_size"]
+    env_group_size = app.state.envs[env_id]["group_size"]
     env_weight = (
-        app.state.envs[env.env_id]["max_context_len"]
-        * app.state.envs[env.env_id]["weight"]
+        app.state.envs[env_id]["max_context_len"]
+        * app.state.envs[env_id]["weight"]
         / total
     )
     env_weight = max(
@@ -507,13 +507,13 @@ async def get_status_env(env: EnvIdentifier):
         group_size = len(item.get("tokens", []))
         if group_size > max_group_size:
             max_group_size = group_size
-        if item.get("env_id") == env.env_id:
+        if item.get("env_id") == env_id:
             # update the group size for the requesting env, handle cases where the group size may be dynamic with max
             env_group_size = max(env_group_size, group_size)
             num_self_sequences_in_queue += group_size
 
     # update the group size for the requesting env
-    app.state.envs[env.env_id]["group_size"] = env_group_size
+    app.state.envs[env_id]["group_size"] = env_group_size
 
     # Calculate minimum sequences allocated to each environment
     batch_size = getattr(app.state, "batchsize", 0)
@@ -523,9 +523,9 @@ async def get_status_env(env: EnvIdentifier):
             env_config.get("connected", False)
             and env_config.get("min_batch_allocation") is not None
         ):
-            env_id = env_config["registered_id"]
+            registered_id = env_config["registered_id"]
             min_sequences = int(batch_size * env_config["min_batch_allocation"])
-            min_sequences_by_env[env_id] = min_sequences
+            min_sequences_by_env[registered_id] = min_sequences
 
     # Count sequences and calculate packed groups for each environment
     import math
@@ -535,16 +535,16 @@ async def get_status_env(env: EnvIdentifier):
     curr_env_total_sequences = 0
 
     for item in queue:
-        env_id = item.get("env_id")
+        item_env_id = item.get("env_id")
         seq_count = len(item.get("tokens", []))
 
         # Special handling for the requesting environment
-        if env_id == env.env_id:
+        if item_env_id == env_id:
             curr_env_total_sequences += seq_count
         else:
-            if env_id not in sequences_by_env:
-                sequences_by_env[env_id] = 0
-            sequences_by_env[env_id] += seq_count
+            if item_env_id not in sequences_by_env:
+                sequences_by_env[item_env_id] = 0
+            sequences_by_env[item_env_id] += seq_count
 
     # Calculate packed groups for each environment (excluding the requesting env)
     if max_group_size > 1:

--- a/atroposlib/envs/base.py
+++ b/atroposlib/envs/base.py
@@ -1015,7 +1015,7 @@ class BaseEnv(ABC):
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 f"{self.config.rollout_server_url}/status-env",
-                json={"env_id": self.env_id},
+                params={"env_id": self.env_id},
             ) as resp:
                 self.status_dict = await parse_http_response(resp, logger)
                 new_weight = self.status_dict["env_weight"]

--- a/atroposlib/tests/test_api_compression.py
+++ b/atroposlib/tests/test_api_compression.py
@@ -256,7 +256,7 @@ class TestAPICompression:
         assert post_response.status_code == 200
 
         status_response = requests.get(
-            "http://localhost:8000/status-env", json={"env_id": env_id}
+            "http://localhost:8000/status-env", params={"env_id": env_id}
         )
         assert status_response.status_code == 200
         status_data = status_response.json()


### PR DESCRIPTION
## Summary

`GET /status-env` currently requires a JSON request body containing `env_id`, which violates [RFC 9110 §9.3.1](https://www.rfc-editor.org/rfc/rfc9110.html#name-get). A GET with body semantics is non-standard and is silently stripped by common HTTP intermediaries (nginx, Cloudflare, AWS ALB), breaking the endpoint whenever the rollout server sits behind one.

This PR switches `env_id` to a standard query parameter (`GET /status-env?env_id=<int>`), which is the idiomatic FastAPI pattern for this case.

## Changes

- `atroposlib/api/server.py` — endpoint now takes `env_id: int` as a query parameter; renamed one shadowed loop-local so the new parameter name is preserved through the function body.
- `atroposlib/envs/base.py` — caller uses `params={"env_id": ...}` instead of `json=...`.
- `atroposlib/tests/test_api_compression.py` — test updated to the same.
- `atroposlib/api/README.md` — removes the outdated note about body-on-GET and documents the query parameter.
- `atroposlib/api/env_interaction.md` — sequence diagram updated to reflect the query form.

## Notes

- `POST /disconnect-env`, which is the other user of `EnvIdentifier`, is unaffected — it was already a POST and is spec-compliant.
- This is a breaking change for any third-party client that was sending a JSON body on the GET. The only in-tree caller is `AtroposBaseEnv.get_status`, which is updated here.

Closes #449
