### PR TITLE
fix: Implement strict dtype validation for shared vLLM tensors

### DIFF
--- a/example_trainer/model.py
+++ b/example_trainer/model.py
@@ -471,82 +471,82 @@ def _reconstruct_shared_tensors(
         if "ipc_handle_b64" not in ipc_info:
             return None
 
-        try:
-            device_index = ipc_info["device_index"]
-            ipc_handle = base64.b64decode(ipc_info["ipc_handle_b64"])
-            storage_size = ipc_info["storage_size"]
-            storage_offset_orig = ipc_info["storage_offset_orig"]
-            ref_counter_handle = base64.b64decode(ipc_info["ref_counter_handle_b64"])
-            ref_counter_offset = ipc_info["ref_counter_offset"]
-            event_handle = base64.b64decode(ipc_info["event_handle_b64"])
-            event_sync_required = ipc_info["event_sync_required"]
+        device_index = ipc_info["device_index"]
+        ipc_handle = base64.b64decode(ipc_info["ipc_handle_b64"])
+        storage_size = ipc_info["storage_size"]
+        storage_offset_orig = ipc_info["storage_offset_orig"]
+        ref_counter_handle = base64.b64decode(ipc_info["ref_counter_handle_b64"])
+        ref_counter_offset = ipc_info["ref_counter_offset"]
+        event_handle = base64.b64decode(ipc_info["event_handle_b64"])
+        event_sync_required = ipc_info["event_sync_required"]
 
-            share_tuple = (
-                device_index,
-                ipc_handle,
-                storage_size,
-                storage_offset_orig,
-                ref_counter_handle,
-                ref_counter_offset,
-                event_handle,
-                event_sync_required,
+        share_tuple = (
+            device_index,
+            ipc_handle,
+            storage_size,
+            storage_offset_orig,
+            ref_counter_handle,
+            ref_counter_offset,
+            event_handle,
+            event_sync_required,
+        )
+
+        storage = torch.UntypedStorage._new_shared_cuda(*share_tuple)
+        dtype = getattr(torch, ipc_info["dtype"].replace("torch.", ""))
+        
+        # CRITICAL: Validate dtype against trainer config to prevent silent corruption
+        expected_dtype = getattr(torch, config.dtype) if isinstance(config.dtype, str) else config.dtype
+        if dtype != expected_dtype:
+            raise RuntimeError(
+                f"[Setup] Dtype mismatch for {vllm_name}: vLLM has {dtype}, "
+                f"but Trainer expects {expected_dtype}. This would cause silent corruption."
             )
 
-            storage = torch.UntypedStorage._new_shared_cuda(*share_tuple)
-            dtype = getattr(torch, ipc_info["dtype"].replace("torch.", ""))
-            tensor = torch.tensor([], dtype=dtype, device=f"cuda:{device_index}")
-            tensor.set_(
-                storage,
-                storage_offset=ipc_info["tensor_storage_offset"],
-                size=ipc_info["shape"],
-                stride=ipc_info["stride"],
-            )
+        tensor = torch.tensor([], dtype=dtype, device=f"cuda:{device_index}")
+        tensor.set_(
+            storage,
+            storage_offset=ipc_info["tensor_storage_offset"],
+            size=ipc_info["shape"],
+            stride=ipc_info["stride"],
+        )
 
-            vllm_tensor_cache[vllm_name] = tensor
-            return tensor
-
-        except Exception as e:
-            print(f"[Setup] Failed to reconstruct {vllm_name}: {e}", flush=True)
-            return None
+        vllm_tensor_cache[vllm_name] = tensor
+        return tensor
 
     for hf_name, mapping_info in vllm_to_hf_mapping.items():
-        try:
-            if isinstance(mapping_info, dict):
-                # Fused mapping - slice the source tensor
-                vllm_name = mapping_info["source"]
-                slice_start, slice_end = mapping_info["slice"]
-                slice_dim = mapping_info["dim"]
+        if isinstance(mapping_info, dict):
+            # Fused mapping - slice the source tensor
+            vllm_name = mapping_info["source"]
+            slice_start, slice_end = mapping_info["slice"]
+            slice_dim = mapping_info["dim"]
 
-                full_tensor = reconstruct_vllm_tensor(vllm_name)
-                if full_tensor is None:
-                    continue
+            full_tensor = reconstruct_vllm_tensor(vllm_name)
+            if full_tensor is None:
+                continue
 
-                # Create VIEW (not copy) into the fused tensor
-                if slice_dim == 0:
-                    tensor = full_tensor[slice_start:slice_end]
-                else:
-                    tensor = full_tensor.narrow(
-                        slice_dim, slice_start, slice_end - slice_start
-                    )
-
-                tensor.requires_grad_(True)
-                hf_state_dict[hf_name] = tensor
-                fused_count += 1
-                attached_count += 1
-
+            # Create VIEW (not copy) into the fused tensor
+            if slice_dim == 0:
+                tensor = full_tensor[slice_start:slice_end]
             else:
-                # Direct mapping
-                vllm_name = mapping_info
-                tensor = reconstruct_vllm_tensor(vllm_name)
-                if tensor is None:
-                    continue
+                tensor = full_tensor.narrow(
+                    slice_dim, slice_start, slice_end - slice_start
+                )
 
-                tensor.requires_grad_(True)
-                hf_state_dict[hf_name] = tensor
-                attached_count += 1
+            tensor.requires_grad_(True)
+            hf_state_dict[hf_name] = tensor
+            fused_count += 1
+            attached_count += 1
 
-        except Exception as e:
-            print(f"[Setup] Failed to attach {hf_name}: {e}", flush=True)
+        else:
+            # Direct mapping
+            vllm_name = mapping_info
+            tensor = reconstruct_vllm_tensor(vllm_name)
+            if tensor is None:
+                continue
+
+            tensor.requires_grad_(True)
+            hf_state_dict[hf_name] = tensor
+            attached_count += 1
 
     return hf_state_dict, attached_count, fused_count
 

--- a/example_trainer/model.py
+++ b/example_trainer/model.py
@@ -493,9 +493,13 @@ def _reconstruct_shared_tensors(
 
         storage = torch.UntypedStorage._new_shared_cuda(*share_tuple)
         dtype = getattr(torch, ipc_info["dtype"].replace("torch.", ""))
-        
+
         # CRITICAL: Validate dtype against trainer config to prevent silent corruption
-        expected_dtype = getattr(torch, config.dtype) if isinstance(config.dtype, str) else config.dtype
+        expected_dtype = (
+            getattr(torch, config.dtype)
+            if isinstance(config.dtype, str)
+            else config.dtype
+        )
         if dtype != expected_dtype:
             raise RuntimeError(
                 f"[Setup] Dtype mismatch for {vllm_name}: vLLM has {dtype}, "


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR hardens the Single Copy (Shared Memory) mode by implementing mandatory bit-perfect dtype validation during CUDA IPC attachment.

**Key Changes:**
1. **Dtype Assertion**: Reconstruct_vllm_tensor now explicitly validates the vLLM source dtype against the Trainer's expected configuration. This prevents "Silent Data Corruption" where FP16 bits are misinterpreted as BF16.
2. **Fail-Fast Error Handling**: Removed broad `try-except` blocks that were masking initialization failures. If a weight fails to attach, the system now raises a `RuntimeError` immediately rather than continuing with uninitialized (meta) weights.

### Related Issues
<!-- Link the issue you opened for this branch here -->
Closes #454 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (now raises errors instead of silently returning None)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions
