### PR TITLE
fix: Implement on-policy teacher distillation with KL loss

### DIFF
--- a/example_trainer/data.py
+++ b/example_trainer/data.py
@@ -137,9 +137,13 @@ def pad_data_to_good_offset(
                     padded_logprobs[:n_to_copy] = raw_logprobs[:n_to_copy]
                     inference_logprobs_padded.append(padded_logprobs[1:])
                 else:
-                    inference_logprobs_padded.append(np.full(token_setup_len - 1, 1.0, dtype=np.float32))
+                    inference_logprobs_padded.append(
+                        np.full(token_setup_len - 1, 1.0, dtype=np.float32)
+                    )
             elif extract_inference_logprobs:
-                inference_logprobs_padded.append(np.full(token_setup_len - 1, 1.0, dtype=np.float32))
+                inference_logprobs_padded.append(
+                    np.full(token_setup_len - 1, 1.0, dtype=np.float32)
+                )
 
             # Extract and pad distillation data (Teacher Distillation)
             if "distill_token_ids" in item and item["distill_token_ids"] is not None:
@@ -148,25 +152,33 @@ def pad_data_to_good_offset(
                     d_tokens = np.array(item["distill_token_ids"][i], dtype=np.int32)
                     d_logprobs = np.array(item["distill_logprobs"][i], dtype=np.float32)
                     K = d_tokens.shape[1]
-                    
+
                     # Pad seq_len to match token_setup_len
                     padded_d_tokens = np.zeros((token_setup_len, K), dtype=np.int32)
                     padded_d_logprobs = np.zeros((token_setup_len, K), dtype=np.float32)
-                    
+
                     n_copy = min(len(d_tokens), token_setup_len)
                     padded_d_tokens[:n_copy] = d_tokens[:n_copy]
                     padded_d_logprobs[:n_copy] = d_logprobs[:n_copy]
-                    
+
                     # Shift by 1 for causal
                     distill_token_ids.append(padded_d_tokens[1:])
                     distill_logprobs.append(padded_d_logprobs[1:])
                 else:
-                    distill_token_ids.append(np.zeros((token_setup_len - 1, 1), dtype=np.int32))
-                    distill_logprobs.append(np.zeros((token_setup_len - 1, 1), dtype=np.float32))
+                    distill_token_ids.append(
+                        np.zeros((token_setup_len - 1, 1), dtype=np.int32)
+                    )
+                    distill_logprobs.append(
+                        np.zeros((token_setup_len - 1, 1), dtype=np.float32)
+                    )
             else:
                 # Use small size placeholder
-                distill_token_ids.append(np.zeros((token_setup_len - 1, 1), dtype=np.int32))
-                distill_logprobs.append(np.zeros((token_setup_len - 1, 1), dtype=np.float32))
+                distill_token_ids.append(
+                    np.zeros((token_setup_len - 1, 1), dtype=np.int32)
+                )
+                distill_logprobs.append(
+                    np.zeros((token_setup_len - 1, 1), dtype=np.float32)
+                )
 
             # Extract temperature (priority: override > generation_params > group_overrides > 1.0)
             t = 1.0

--- a/example_trainer/data.py
+++ b/example_trainer/data.py
@@ -125,33 +125,48 @@ def pad_data_to_good_offset(
             # - 1.0 for prompt tokens (masked positions)
             # - actual negative logprobs for generated tokens
             # We just need to pad to match the sequence length
+            # Extract and pad inference logprobs to match labels shape
             if extract_inference_logprobs and "inference_logprobs" in item:
                 if i < len(item["inference_logprobs"]):
                     raw_logprobs = np.array(
                         item["inference_logprobs"][i], dtype=np.float32
                     )
                     has_any_logprobs = True
-
-                    # Create padded logprobs array matching token_setup_len
-                    # Fill with 1.0 (the masked token placeholder value) for padding
                     padded_logprobs = np.full(token_setup_len, 1.0, dtype=np.float32)
-
-                    # Copy raw_logprobs directly - they're already aligned with tokens
                     n_to_copy = min(len(raw_logprobs), token_setup_len)
                     padded_logprobs[:n_to_copy] = raw_logprobs[:n_to_copy]
-
-                    # Shift by 1 to match causal label shift
                     inference_logprobs_padded.append(padded_logprobs[1:])
                 else:
-                    # No logprobs for this sample, use 1.0
-                    inference_logprobs_padded.append(
-                        np.full(token_setup_len - 1, 1.0, dtype=np.float32)
-                    )
+                    inference_logprobs_padded.append(np.full(token_setup_len - 1, 1.0, dtype=np.float32))
             elif extract_inference_logprobs:
-                # No inference_logprobs in item, use 1.0
-                inference_logprobs_padded.append(
-                    np.full(token_setup_len - 1, 1.0, dtype=np.float32)
-                )
+                inference_logprobs_padded.append(np.full(token_setup_len - 1, 1.0, dtype=np.float32))
+
+            # Extract and pad distillation data (Teacher Distillation)
+            if "distill_token_ids" in item and item["distill_token_ids"] is not None:
+                if i < len(item["distill_token_ids"]):
+                    # Shape: [seq_len, K]
+                    d_tokens = np.array(item["distill_token_ids"][i], dtype=np.int32)
+                    d_logprobs = np.array(item["distill_logprobs"][i], dtype=np.float32)
+                    K = d_tokens.shape[1]
+                    
+                    # Pad seq_len to match token_setup_len
+                    padded_d_tokens = np.zeros((token_setup_len, K), dtype=np.int32)
+                    padded_d_logprobs = np.zeros((token_setup_len, K), dtype=np.float32)
+                    
+                    n_copy = min(len(d_tokens), token_setup_len)
+                    padded_d_tokens[:n_copy] = d_tokens[:n_copy]
+                    padded_d_logprobs[:n_copy] = d_logprobs[:n_copy]
+                    
+                    # Shift by 1 for causal
+                    distill_token_ids.append(padded_d_tokens[1:])
+                    distill_logprobs.append(padded_d_logprobs[1:])
+                else:
+                    distill_token_ids.append(np.zeros((token_setup_len - 1, 1), dtype=np.int32))
+                    distill_logprobs.append(np.zeros((token_setup_len - 1, 1), dtype=np.float32))
+            else:
+                # Use small size placeholder
+                distill_token_ids.append(np.zeros((token_setup_len - 1, 1), dtype=np.int32))
+                distill_logprobs.append(np.zeros((token_setup_len - 1, 1), dtype=np.float32))
 
             # Extract temperature (priority: override > generation_params > group_overrides > 1.0)
             t = 1.0

--- a/example_trainer/training.py
+++ b/example_trainer/training.py
@@ -70,6 +70,9 @@ def compute_grpo_loss(
     gradient_accumulation_steps: int,
     inference_logprobs: Optional[torch.Tensor] = None,
     clip_eps: float = 0.2,
+    distill_token_ids: Optional[torch.Tensor] = None,
+    distill_logprobs: Optional[torch.Tensor] = None,
+    distill_alpha: float = 0.1,
 ) -> Tuple[torch.Tensor, dict]:
     """
     Compute GRPO (Group Relative Policy Optimization) loss for a single micro-batch.
@@ -189,6 +192,32 @@ def compute_grpo_loss(
 
         total_loss = policy_loss / gradient_accumulation_steps
 
+        # === Teacher Distillation Loss (KL) ===
+        distill_loss_val = 0.0
+        if distill_token_ids is not None and distill_logprobs is not None:
+            # Move to device/dtype
+            d_token_ids = distill_token_ids.to(logp_per_token.device)
+            d_logprobs = distill_logprobs.to(logp_per_token.device, logp_per_token.dtype)
+            
+            # Check if we actually have top-K data (not just placeholders)
+            if d_token_ids.shape[-1] > 1 or d_token_ids.max() > 0:
+                # Student logprobs for the teacher's top-K tokens
+                # Shape: [batch, seq_len, K]
+                student_logp_at_k = F.log_softmax(scaled_logits, dim=-1).gather(dim=-1, index=d_token_ids)
+                
+                # Re-normalize both distributions over the top-K subset
+                teacher_logp_renorm = F.log_softmax(d_logprobs, dim=-1)
+                student_logp_renorm = F.log_softmax(student_logp_at_k, dim=-1)
+                
+                # KL(Teacher || Student) = \sum P_teacher * (log P_teacher - log P_student)
+                kl_per_token = (teacher_logp_renorm.exp() * (teacher_logp_renorm - student_logp_renorm)).sum(dim=-1)
+                
+                # Masked average distillation loss
+                distill_loss = (kl_per_token * mask).sum() / mask_sum.sum()
+                distill_loss_val = distill_loss.item()
+                
+                total_loss += (distill_alpha * distill_loss) / gradient_accumulation_steps
+
         # Compute metrics for logging
         with torch.no_grad():
             # Fraction of tokens where ratio was clipped
@@ -253,6 +282,7 @@ def compute_grpo_loss(
         "logprob_diff_mean": logprob_diff_mean,
         "logprob_diff_abs_mean": logprob_diff_abs_mean,
         "logprob_diff_max": logprob_diff_max,
+        "distill_loss": distill_loss_val,
     }
 
     return total_loss, metrics
@@ -268,6 +298,8 @@ def run_training_step(
     config: TrainingConfig,
     step_idx: int,
     inference_logprob_batches: Optional[List[torch.Tensor]] = None,
+    distill_token_id_batches: Optional[List[torch.Tensor]] = None,
+    distill_logprob_batches: Optional[List[torch.Tensor]] = None,
 ) -> dict:
     """
     Run a single training step with gradient accumulation.
@@ -305,6 +337,7 @@ def run_training_step(
     grad_norm = 0.0
     all_training_logprobs: List[torch.Tensor] = []
     all_inference_logprobs: List[torch.Tensor] = []
+    total_distill_loss = 0.0
 
     # Get GRPO hyperparameters from config
     clip_eps = getattr(config, "clip_eps", 0.2)
@@ -336,6 +369,15 @@ def run_training_step(
         ):
             inf_logprobs = inference_logprob_batches[batch_idx]
 
+        # Get distillation batches if available
+        d_tokens = None
+        if distill_token_id_batches is not None and batch_idx < len(distill_token_id_batches):
+            d_tokens = distill_token_id_batches[batch_idx]
+            
+        d_logprobs = None
+        if distill_logprob_batches is not None and batch_idx < len(distill_logprob_batches):
+            d_logprobs = distill_logprob_batches[batch_idx]
+
         loss, metrics = compute_grpo_loss(
             model,
             tokens,
@@ -345,6 +387,9 @@ def run_training_step(
             config.gradient_accumulation_steps,
             inference_logprobs=inf_logprobs,
             clip_eps=clip_eps,
+            distill_token_ids=d_tokens,
+            distill_logprobs=d_logprobs,
+            distill_alpha=getattr(config, "distill_alpha", 0.1),
         )
 
         loss.backward()
@@ -353,6 +398,7 @@ def run_training_step(
         total_neg_logp += metrics["neg_logp"]
         total_pos += metrics["pos_count"]
         total_neg += metrics["neg_count"]
+        total_distill_loss += metrics.get("distill_loss", 0.0)
 
         # Accumulate GRPO-specific metrics
         total_mean_ratio += metrics.get("mean_ratio", 1.0)
@@ -399,6 +445,7 @@ def run_training_step(
         # GRPO-specific metrics (averaged over batches)
         "mean_ratio": total_mean_ratio / num_batches,
         "clipped_fraction": total_clipped_fraction / num_batches,
+        "distill_loss": total_distill_loss / num_batches,
     }
 
     # Compute logprob alignment stats for monitoring
@@ -466,6 +513,9 @@ def log_metrics(
         else f"{metrics['loss']:.4f}"
     )
     print(f"  Loss: {loss_str}, Grad norm: {metrics['grad_norm']:.4f}{timing_str}")
+    
+    if "distill_loss" in metrics and metrics["distill_loss"] > 0:
+        print(f"    Distill KL: {metrics['distill_loss']:.6f}")
 
     # GRPO metrics line: ratio and clipping
     mean_ratio = metrics.get("mean_ratio", 1.0)
@@ -494,6 +544,7 @@ def log_metrics(
             # GRPO-specific metrics
             "grpo/mean_ratio": mean_ratio,
             "grpo/clipped_fraction": clipped_frac,
+            "train/distill_loss": metrics.get("distill_loss", 0.0),
         }
         # Add timing metrics if present
         for key in [

--- a/example_trainer/training.py
+++ b/example_trainer/training.py
@@ -197,26 +197,35 @@ def compute_grpo_loss(
         if distill_token_ids is not None and distill_logprobs is not None:
             # Move to device/dtype
             d_token_ids = distill_token_ids.to(logp_per_token.device)
-            d_logprobs = distill_logprobs.to(logp_per_token.device, logp_per_token.dtype)
-            
+            d_logprobs = distill_logprobs.to(
+                logp_per_token.device, logp_per_token.dtype
+            )
+
             # Check if we actually have top-K data (not just placeholders)
             if d_token_ids.shape[-1] > 1 or d_token_ids.max() > 0:
                 # Student logprobs for the teacher's top-K tokens
                 # Shape: [batch, seq_len, K]
-                student_logp_at_k = F.log_softmax(scaled_logits, dim=-1).gather(dim=-1, index=d_token_ids)
-                
+                student_logp_at_k = F.log_softmax(scaled_logits, dim=-1).gather(
+                    dim=-1, index=d_token_ids
+                )
+
                 # Re-normalize both distributions over the top-K subset
                 teacher_logp_renorm = F.log_softmax(d_logprobs, dim=-1)
                 student_logp_renorm = F.log_softmax(student_logp_at_k, dim=-1)
-                
+
                 # KL(Teacher || Student) = \sum P_teacher * (log P_teacher - log P_student)
-                kl_per_token = (teacher_logp_renorm.exp() * (teacher_logp_renorm - student_logp_renorm)).sum(dim=-1)
-                
+                kl_per_token = (
+                    teacher_logp_renorm.exp()
+                    * (teacher_logp_renorm - student_logp_renorm)
+                ).sum(dim=-1)
+
                 # Masked average distillation loss
                 distill_loss = (kl_per_token * mask).sum() / mask_sum.sum()
                 distill_loss_val = distill_loss.item()
-                
-                total_loss += (distill_alpha * distill_loss) / gradient_accumulation_steps
+
+                total_loss += (
+                    distill_alpha * distill_loss
+                ) / gradient_accumulation_steps
 
         # Compute metrics for logging
         with torch.no_grad():
@@ -371,11 +380,15 @@ def run_training_step(
 
         # Get distillation batches if available
         d_tokens = None
-        if distill_token_id_batches is not None and batch_idx < len(distill_token_id_batches):
+        if distill_token_id_batches is not None and batch_idx < len(
+            distill_token_id_batches
+        ):
             d_tokens = distill_token_id_batches[batch_idx]
-            
+
         d_logprobs = None
-        if distill_logprob_batches is not None and batch_idx < len(distill_logprob_batches):
+        if distill_logprob_batches is not None and batch_idx < len(
+            distill_logprob_batches
+        ):
             d_logprobs = distill_logprob_batches[batch_idx]
 
         loss, metrics = compute_grpo_loss(
@@ -513,7 +526,7 @@ def log_metrics(
         else f"{metrics['loss']:.4f}"
     )
     print(f"  Loss: {loss_str}, Grad norm: {metrics['grad_norm']:.4f}{timing_str}")
-    
+
     if "distill_loss" in metrics and metrics["distill_loss"] > 0:
         print(f"    Distill KL: {metrics['distill_loss']:.6f}")
 


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR completes the teacher-student distillation pipeline, which was previously collecting teacher data but ignoring it during training.

**Key Changes:**
1. **Data Pipeline**: Updated `pad_data_to_good_offset` to extract and pad `distill_token_ids` and `distill_logprobs`. Implemented causal shifting (shift by 1) to align teacher labels with student predictions.
2. **On-Policy KL Loss**: Implemented a re-normalized KL-divergence loss in `compute_grpo_loss`. The student now learns directly from the teacher's top-K distribution.
3. **Telemetry**: Added `distill_loss` to the metrics suite and Weights & Biases logging for training visibility.

### Related Issues
<!-- Link the issue you opened for this branch here -->
Closes #456 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (Restores the distillation objective function)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions
