### PR TITLE
fix: Implement robust advantage normalization for low-variance groups

### DIFF
--- a/example_trainer/data.py
+++ b/example_trainer/data.py
@@ -80,12 +80,12 @@ def pad_data_to_good_offset(
         if len(scores) > 1:
             mean = scores.mean()
             std = scores.std()
-            
+
             # Use a robust epsilon that scales with the magnitude of the scores
             # This prevents "explosion" when std is tiny due to floating point noise
             # but still allows signal when there's actual variance.
             eps = max(1e-8, 1e-4 * np.abs(mean))
-            
+
             if std > eps:
                 scores = (scores - mean) / std
             else:
@@ -95,7 +95,7 @@ def pad_data_to_good_offset(
         else:
             # For group size 1, advantage is always 0 relative to self
             scores = np.zeros_like(scores)
-            
+
         item["scores"] = scores.astype(np.float32)
 
         # Handle score overrides

--- a/example_trainer/data.py
+++ b/example_trainer/data.py
@@ -75,12 +75,28 @@ def pad_data_to_good_offset(
     has_any_logprobs = False
 
     for item in data["batch"]:
-        # Normalize advantage scores
-        scores = np.array(item["scores"])
+        # Normalize advantage scores per group (GRPO style)
+        scores = np.array(item["scores"], dtype=np.float64)
         if len(scores) > 1:
-            scores = scores - scores.mean()
-            scores = scores / max(scores.std(), 1e-8)
-        item["scores"] = scores
+            mean = scores.mean()
+            std = scores.std()
+            
+            # Use a robust epsilon that scales with the magnitude of the scores
+            # This prevents "explosion" when std is tiny due to floating point noise
+            # but still allows signal when there's actual variance.
+            eps = max(1e-8, 1e-4 * np.abs(mean))
+            
+            if std > eps:
+                scores = (scores - mean) / std
+            else:
+                # If std is too small, all items in the group are essentially equal
+                # We set advantages to 0 to avoid training on noise
+                scores = scores - mean
+        else:
+            # For group size 1, advantage is always 0 relative to self
+            scores = np.zeros_like(scores)
+            
+        item["scores"] = scores.astype(np.float32)
 
         # Handle score overrides
         if item["overrides"] is not None:


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR addresses numerical instability in the advantage normalization logic that previously caused gradient spikes and training divergence.

**Key Changes:**
1. **Magnitude-Relative Epsilon**: Replaced the static `1e-8` floor with a robust `max(1e-8, 1e-4 * abs(mean))` threshold. This prevents tiny floating-point variance in uniform reward groups from being amplified into massive advantage signals.
2. **Stable Centering**: If reward variance is below the threshold, the code now centers the advantages (`scores - mean`) without scaling, maintaining zero-mean properties without introducing noise.

### Related Issues
<!-- Link the issue you opened for this branch here -->
Closes #457 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (improved numerical stability)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (Inline comments)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
