### PR TITLE
fix: Add bridge config cleanup to prevent stale CUDA IPC leaks

### DIFF
--- a/example_trainer/vllm_manager.py
+++ b/example_trainer/vllm_manager.py
@@ -19,6 +19,7 @@ from .config import TrainingConfig
 
 # Global variable to keep track of the vLLM process
 _vllm_process: Optional[subprocess.Popen] = None
+_vllm_config_path: Optional[str] = None
 
 
 def is_port_in_use(port: int) -> bool:
@@ -103,6 +104,16 @@ def cleanup_vllm():
             _vllm_process.wait()
             print("vLLM process killed.")
         _vllm_process = None
+    
+    # Also cleanup the bridge config if we know where it is
+    global _vllm_config_path
+    if _vllm_config_path and os.path.exists(_vllm_config_path):
+        try:
+            print(f"Cleaning up bridge config: {_vllm_config_path}")
+            os.remove(_vllm_config_path)
+        except Exception as e:
+            print(f"  WARNING: Could not delete bridge config: {e}")
+        _vllm_config_path = None
 
 
 # Register cleanup on module load
@@ -156,6 +167,21 @@ def launch_vllm_server(
         "--gpu-memory-utilization",
         str(config.vllm_gpu_memory_utilization),
     ]
+
+    # Track the config path for cleanup
+    global _vllm_config_path
+    if config.vllm_config_path:
+        _vllm_config_path = config.vllm_config_path
+    else:
+        log_dir = os.environ.get("LOGDIR", ".")
+        _vllm_config_path = os.path.join(log_dir, "vllm_bridge_config.json")
+    
+    # Remove stale config if it exists before launching
+    if os.path.exists(_vllm_config_path):
+        try:
+            os.remove(_vllm_config_path)
+        except Exception:
+            pass
 
     # Add served-model-name if using checkpoint path
     if model_path != config.model_name:

--- a/example_trainer/vllm_manager.py
+++ b/example_trainer/vllm_manager.py
@@ -104,7 +104,7 @@ def cleanup_vllm():
             _vllm_process.wait()
             print("vLLM process killed.")
         _vllm_process = None
-    
+
     # Also cleanup the bridge config if we know where it is
     global _vllm_config_path
     if _vllm_config_path and os.path.exists(_vllm_config_path):
@@ -175,7 +175,7 @@ def launch_vllm_server(
     else:
         log_dir = os.environ.get("LOGDIR", ".")
         _vllm_config_path = os.path.join(log_dir, "vllm_bridge_config.json")
-    
+
     # Remove stale config if it exists before launching
     if os.path.exists(_vllm_config_path):
         try:


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR implements automatic cleanup for the `vllm_bridge_config.json` file, resolving a common failure mode where subsequent training runs would crash while trying to attach to stale CUDA IPC handles.

**Key Changes:**
1. **Pre-flight Purge**: The vLLM manager now explicitly deletes any existing bridge config *before* launching a new server instance.
2. **Graceful Exit Cleanup**: Registered an `atexit` handler to purge the config file when the Python process terminates, ensuring no leakage of stale state on the filesystem.

### Related Issues
<!-- Link the issue you opened for this branch here -->
Closes #458 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (improved process lifecycle management)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions
