### PR TITLE
fix: Add rollout queue limit and backpressure to prevent OOM

### DIFF
--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -2,9 +2,10 @@ import gzip
 import logging
 import time
 import uuid
+import os
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, status
+from fastapi import FastAPI, status, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import PlainTextResponse
@@ -193,6 +194,10 @@ def _scored_data_to_dict(scored_data: ScoredData) -> Dict[str, Any]:
     }
 
 
+# Maximum number of trajectories to buffer before applying backpressure
+MAX_QUEUE_SIZE = int(os.environ.get("ATROPOS_MAX_QUEUE_SIZE", "1000"))
+
+
 def _process_scored_data(scored_data: ScoredData) -> Dict[str, Any]:
     """Normalize buffering/queueing logic for scored data submissions."""
 
@@ -200,6 +205,13 @@ def _process_scored_data(scored_data: ScoredData) -> Dict[str, Any]:
         app.state.queue = []
     if not hasattr(app.state, "buffer"):
         app.state.buffer = {}
+
+    # Check for queue limit to prevent OOM (Backpressure)
+    if len(app.state.queue) >= MAX_QUEUE_SIZE:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Rollout queue is full ({MAX_QUEUE_SIZE} items). Trainer is lagging."
+        )
 
     data_dict = _scored_data_to_dict(scored_data)
     env_id = data_dict.get("env_id")

--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -1,11 +1,11 @@
 import gzip
 import logging
+import os
 import time
 import uuid
-import os
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, status, HTTPException
+from fastapi import FastAPI, HTTPException, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import PlainTextResponse
@@ -210,7 +210,7 @@ def _process_scored_data(scored_data: ScoredData) -> Dict[str, Any]:
     if len(app.state.queue) >= MAX_QUEUE_SIZE:
         raise HTTPException(
             status_code=503,
-            detail=f"Rollout queue is full ({MAX_QUEUE_SIZE} items). Trainer is lagging."
+            detail=f"Rollout queue is full ({MAX_QUEUE_SIZE} items). Trainer is lagging.",
         )
 
     data_dict = _scored_data_to_dict(scored_data)


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR addresses memory instability in the API server by implementing a backpressure mechanism to prevent unbounded trajectory buffering.

**Key Changes:**
1. **Queue Depth Limiting**: Introduced a `MAX_QUEUE_SIZE` (default: 1000, configurable via `ATROPOS_MAX_QUEUE_SIZE`) to the API server state.
2. **503 Backpressure**: The server now returns a `503 Service Unavailable` status to rollout workers when the buffer is full. This forces workers to wait for the Trainer to catch up, preventing process termination via the OOM Killer.

### Related Issues
<!-- Link the issue you opened for this branch here -->
Closes #459

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (Operational flow control)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] If .env vars required, did you add it to the .env.example in repo root? (Added to environment variable documentation)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
