### PR TITLE
fix: Harden process termination with PID verification

### DIFF
--- a/example_trainer/vllm_manager.py
+++ b/example_trainer/vllm_manager.py
@@ -39,17 +39,29 @@ def kill_process_on_port(port: int, timeout: float = 5.0) -> bool:
     print(f"  Port {port} is in use, attempting to kill existing process...")
 
     try:
-        # Try to find and kill the process using lsof (Linux/Mac)
+        # Try to find the process using lsof
         result = subprocess.run(
             ["lsof", "-t", "-i", f":{port}"], capture_output=True, text=True, timeout=5
         )
         if result.stdout.strip():
             pids = result.stdout.strip().split("\n")
-            print(f"  Killing {len(pids)} processes on port {port}...")
-            for pid in pids:
+            print(f"  Found {len(pids)} processes on port {port}, verifying before killing...")
+            
+            for pid_str in pids:
                 try:
-                    os.kill(int(pid), signal.SIGTERM)
-                except (ProcessLookupError, ValueError):
+                    pid = int(pid_str)
+                    # Safety check: verify this is likely our process (vllm, python, etc)
+                    with open(f"/proc/{pid}/cmdline", "rb") as f:
+                        cmdline = f.read().decode().replace('\0', ' ')
+                    
+                    is_ours = any(x in cmdline.lower() for x in ["vllm", "python", "atropos"])
+                    
+                    if is_ours:
+                        print(f"    Killing process {pid}: {cmdline[:50]}...")
+                        os.kill(pid, signal.SIGTERM)
+                    else:
+                        print(f"    WARNING: Process {pid} on port {port} does not look like vLLM! Skipping.")
+                except (ProcessLookupError, ValueError, FileNotFoundError):
                     pass
 
             # Wait for port to be free
@@ -61,18 +73,15 @@ def kill_process_on_port(port: int, timeout: float = 5.0) -> bool:
                 time.sleep(0.5)
 
             # Force kill if still running
-            killed_count = 0
-            for pid in pids:
+            for pid_str in pids:
                 try:
-                    os.kill(int(pid), signal.SIGKILL)
-                    killed_count += 1
-                except (ProcessLookupError, ValueError):
+                    pid = int(pid_str)
+                    with open(f"/proc/{pid}/cmdline", "rb") as f:
+                        cmdline = f.read().decode().replace('\0', ' ')
+                    if any(x in cmdline.lower() for x in ["vllm", "python", "atropos"]):
+                        os.kill(pid, signal.SIGKILL)
+                except (ProcessLookupError, ValueError, FileNotFoundError):
                     pass
-            if killed_count > 0:
-                print(f"  Force killed {killed_count} stubborn processes")
-
-            time.sleep(1)
-            return not is_port_in_use(port)
     except FileNotFoundError:
         # lsof not available, try fuser (Linux)
         try:

--- a/example_trainer/vllm_manager.py
+++ b/example_trainer/vllm_manager.py
@@ -45,22 +45,28 @@ def kill_process_on_port(port: int, timeout: float = 5.0) -> bool:
         )
         if result.stdout.strip():
             pids = result.stdout.strip().split("\n")
-            print(f"  Found {len(pids)} processes on port {port}, verifying before killing...")
-            
+            print(
+                f"  Found {len(pids)} processes on port {port}, verifying before killing..."
+            )
+
             for pid_str in pids:
                 try:
                     pid = int(pid_str)
                     # Safety check: verify this is likely our process (vllm, python, etc)
                     with open(f"/proc/{pid}/cmdline", "rb") as f:
-                        cmdline = f.read().decode().replace('\0', ' ')
-                    
-                    is_ours = any(x in cmdline.lower() for x in ["vllm", "python", "atropos"])
-                    
+                        cmdline = f.read().decode().replace("\0", " ")
+
+                    is_ours = any(
+                        x in cmdline.lower() for x in ["vllm", "python", "atropos"]
+                    )
+
                     if is_ours:
                         print(f"    Killing process {pid}: {cmdline[:50]}...")
                         os.kill(pid, signal.SIGTERM)
                     else:
-                        print(f"    WARNING: Process {pid} on port {port} does not look like vLLM! Skipping.")
+                        print(
+                            f"    WARNING: Process {pid} on port {port} does not look like vLLM! Skipping."
+                        )
                 except (ProcessLookupError, ValueError, FileNotFoundError):
                     pass
 
@@ -77,7 +83,7 @@ def kill_process_on_port(port: int, timeout: float = 5.0) -> bool:
                 try:
                     pid = int(pid_str)
                     with open(f"/proc/{pid}/cmdline", "rb") as f:
-                        cmdline = f.read().decode().replace('\0', ' ')
+                        cmdline = f.read().decode().replace("\0", " ")
                     if any(x in cmdline.lower() for x in ["vllm", "python", "atropos"]):
                         os.kill(pid, signal.SIGKILL)
                 except (ProcessLookupError, ValueError, FileNotFoundError):


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR improves the safety of the vLLM manager by ensuring it only terminates processes that are actually associated with the Atropos framework.

**Key Changes:**
1. **PID Command-Line Verification**: Before issuing a `SIGTERM` or `SIGKILL` to a process found on a shared port, the manager now inspects `/proc/{pid}/cmdline`.
2. **Heuristic Filter**: It only kills the process if it contains the keywords `vllm`, `python`, or `atropos`. This prevents the catastrophic race condition where an unrelated system service (like SSH or a database) is accidentally terminated during port reclamation.

### Related Issues
<!-- Link the issue you opened for this branch here -->
Closes #460 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (Safety hardening)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
