### PR TITLE
fix: Make student/teacher model and tokenizer configurable

### DIFF
--- a/environments/gsm8k_server_teacher_distill.py
+++ b/environments/gsm8k_server_teacher_distill.py
@@ -1,3 +1,4 @@
+import os
 from typing import Tuple
 
 from atroposlib.envs.base import APIServerConfig, ServerBaseline
@@ -21,8 +22,13 @@ class GSM8kTeacherDistillEnv(GSM8kEnv, TeacherDistillationEnv):
 
     @classmethod
     def config_init(cls) -> Tuple[TeacherDistillationConfig, ServerBaseline]:
+        # Default model/tokenizer, but allow override via env for flexibility
+        default_model = "NousResearch/DeepHermes-3-Llama-3-3B-Preview"
+        model_name = os.environ.get("STUDENT_MODEL", default_model)
+        tokenizer_name = os.environ.get("STUDENT_TOKENIZER", model_name)
+
         env_config = TeacherDistillationConfig(
-            tokenizer_name="NousResearch/DeepHermes-3-Llama-3-3B-Preview",
+            tokenizer_name=tokenizer_name,
             group_size=8,
             use_wandb=True,
             rollout_server_url="http://localhost:8000",
@@ -35,7 +41,7 @@ class GSM8kTeacherDistillEnv(GSM8kEnv, TeacherDistillationEnv):
             teacher_top_k=4,
         )
         server_config = APIServerConfig(
-            model_name="NousResearch/DeepHermes-3-Llama-3-3B-Preview",
+            model_name=model_name,
             base_url="http://localhost:9001/v1",
             api_key="x",
             num_requests_for_eval=256,
@@ -44,12 +50,19 @@ class GSM8kTeacherDistillEnv(GSM8kEnv, TeacherDistillationEnv):
 
     @classmethod
     def teacher_config_init(cls) -> APIServerConfig:
+        teacher_model = os.environ.get("TEACHER_MODEL", "mock-teacher")
+        # Ensure teacher tokenizer matches teacher model by default
+        teacher_tokenizer = os.environ.get("TEACHER_TOKENIZER", teacher_model)
+        if teacher_model == "mock-teacher" and "TEACHER_TOKENIZER" not in os.environ:
+            # Fallback for mock teacher to use student tokenizer
+            teacher_tokenizer = os.environ.get("STUDENT_TOKENIZER", "NousResearch/DeepHermes-3-Llama-3-3B-Preview")
+
         return APIServerConfig(
             base_url="http://localhost:9003/v1",
-            model_name="mock-teacher",
+            model_name=teacher_model,
             api_key="",
             server_type="vllm",
-            tokenizer_name="NousResearch/DeepHermes-3-Llama-3-3B-Preview",
+            tokenizer_name=teacher_tokenizer,
             timeout=1200,
         )
 

--- a/environments/gsm8k_server_teacher_distill.py
+++ b/environments/gsm8k_server_teacher_distill.py
@@ -55,7 +55,9 @@ class GSM8kTeacherDistillEnv(GSM8kEnv, TeacherDistillationEnv):
         teacher_tokenizer = os.environ.get("TEACHER_TOKENIZER", teacher_model)
         if teacher_model == "mock-teacher" and "TEACHER_TOKENIZER" not in os.environ:
             # Fallback for mock teacher to use student tokenizer
-            teacher_tokenizer = os.environ.get("STUDENT_TOKENIZER", "NousResearch/DeepHermes-3-Llama-3-3B-Preview")
+            teacher_tokenizer = os.environ.get(
+                "STUDENT_TOKENIZER", "NousResearch/DeepHermes-3-Llama-3-3B-Preview"
+            )
 
         return APIServerConfig(
             base_url="http://localhost:9003/v1",


### PR DESCRIPTION
<!--
╭───────────────────────────────────────────────────────────╮
│  ✨  ATROPOS PULL REQUEST TEMPLATE  ✨                    │
╰───────────────────────────────────────────────────────────╯
-->

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
This PR refactors the `GSM8kTeacherDistillEnv` to remove hardcoded model and tokenizer strings, enabling flexibility for multi-model research and cross-architecture distillation.

**Key Changes:**
1. **Dynamic Configuration**: Replaced hardcoded DeepHermes-3 strings with environment variable resolution (`STUDENT_MODEL`, `TEACHER_MODEL`, etc.).
2. **Tokenizer Alignment**: Implemented logic to ensure the tokenizer automatically matches the served model unless explicitly overridden, preventing "TokenId out of range" errors when swapping model families (e.g., Llama to Qwen).

### Related Issues
<!-- Link the issue you opened for this branch here -->
Closes #461 

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code refactor (improved portability)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions
