### PR TITLE
fix(api): GET /status-env via query param, not JSON body

### DIFF
--- a/atroposlib/api/README.md
+++ b/atroposlib/api/README.md
@@ -119,7 +119,7 @@ The API documentation (Swagger UI) will be available at `http://<your-server-ip>
     * **Response:** `{"status": "success"}` or `{"status": "failure", "error": ...}`
 * `GET /status-env`
     * **Description:** Called by a Rollout Handler to get general status plus its calculated sampling weight relative to other connected environments.
-    * **Query Parameter:** Requires `env: EnvIdentifier` model (e.g., `?env_id=0` - actual implementation might differ slightly, check FastAPI docs for query parameter models). **Note:** The code shows `env: EnvIdentifier` as a body parameter for a GET request, which is non-standard. This might need adjustment or testing. Assuming it works via query or a POST instead.
+    * **Query Parameter:** `env_id: int` — the registered environment id, e.g. `GET /status-env?env_id=0`.
     * **Response:** `{"current_step": <step>, "queue_size": <size>, "env_weight": <calculated_weight_float>}`
 
 ### Data Handling

--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -469,7 +469,18 @@ async def get_status():
 
 
 @app.get("/status-env")
-async def get_status_env(env: EnvIdentifier):
+async def get_status_env(env_id: int):
+    """Return per-environment status keyed by `env_id`.
+
+    `env_id` is taken from the query string (e.g. `?env_id=0`). The endpoint
+    previously declared a Pydantic model parameter, which FastAPI bound to the
+    request body — non-standard for GET per RFC 9110 §9.3.1 and stripped by
+    most proxies / CDNs. See issue #449.
+    """
+    # Loops below shadow `env_id` with per-item values; pin the requester's id
+    # under a stable name so later comparisons stay correct.
+    requesting_env_id = env_id
+
     total = sum(
         [
             x["max_context_len"] * max(0.0, x["weight"])
@@ -477,10 +488,10 @@ async def get_status_env(env: EnvIdentifier):
             if x["connected"]
         ]
     )
-    env_group_size = app.state.envs[env.env_id]["group_size"]
+    env_group_size = app.state.envs[env_id]["group_size"]
     env_weight = (
-        app.state.envs[env.env_id]["max_context_len"]
-        * app.state.envs[env.env_id]["weight"]
+        app.state.envs[env_id]["max_context_len"]
+        * app.state.envs[env_id]["weight"]
         / total
     )
     env_weight = max(
@@ -507,13 +518,13 @@ async def get_status_env(env: EnvIdentifier):
         group_size = len(item.get("tokens", []))
         if group_size > max_group_size:
             max_group_size = group_size
-        if item.get("env_id") == env.env_id:
+        if item.get("env_id") == env_id:
             # update the group size for the requesting env, handle cases where the group size may be dynamic with max
             env_group_size = max(env_group_size, group_size)
             num_self_sequences_in_queue += group_size
 
     # update the group size for the requesting env
-    app.state.envs[env.env_id]["group_size"] = env_group_size
+    app.state.envs[env_id]["group_size"] = env_group_size
 
     # Calculate minimum sequences allocated to each environment
     batch_size = getattr(app.state, "batchsize", 0)
@@ -539,7 +550,7 @@ async def get_status_env(env: EnvIdentifier):
         seq_count = len(item.get("tokens", []))
 
         # Special handling for the requesting environment
-        if env_id == env.env_id:
+        if env_id == requesting_env_id:
             curr_env_total_sequences += seq_count
         else:
             if env_id not in sequences_by_env:

--- a/atroposlib/envs/base.py
+++ b/atroposlib/envs/base.py
@@ -1015,7 +1015,7 @@ class BaseEnv(ABC):
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 f"{self.config.rollout_server_url}/status-env",
-                json={"env_id": self.env_id},
+                params={"env_id": self.env_id},
             ) as resp:
                 self.status_dict = await parse_http_response(resp, logger)
                 new_weight = self.status_dict["env_weight"]

--- a/atroposlib/tests/test_api_compression.py
+++ b/atroposlib/tests/test_api_compression.py
@@ -256,7 +256,7 @@ class TestAPICompression:
         assert post_response.status_code == 200
 
         status_response = requests.get(
-            "http://localhost:8000/status-env", json={"env_id": env_id}
+            "http://localhost:8000/status-env", params={"env_id": env_id}
         )
         assert status_response.status_code == 200
         status_data = status_response.json()


### PR DESCRIPTION
Closes #449.

## Bug

\`GET /status-env\` declared \`env: EnvIdentifier\` (a Pydantic \`BaseModel\`), which FastAPI binds to the **request body**. Per [RFC 9110 §9.3.1](https://www.rfc-editor.org/rfc/rfc9110#section-9.3.1), GET requests SHOULD NOT carry content; nginx, Cloudflare, ALB, and most non-aiohttp HTTP clients either strip or refuse the body. The endpoint was unreachable behind common proxies / CDNs and from browser \`fetch\` / Go / Rust clients.

## Fix (option 1 from the issue: clean break to query parameter)

| File | Change |
|---|---|
| \`atroposlib/api/server.py\` | \`get_status_env(env_id: int)\` — taken from \`?env_id=…\`. Pin the requesting id under \`requesting_env_id\` before later loops shadow \`env_id\` with per-item values. |
| \`atroposlib/envs/base.py\` | Client switches \`json={"env_id": …}\` → \`params={"env_id": …}\`. |
| \`atroposlib/tests/test_api_compression.py\` | Same client switch in the API test. |
| \`atroposlib/api/README.md\` | Drop the "non-standard, might need adjustment" hedge; document the query-parameter form. |

\`+21 / -10\` across 4 files.

## Compatibility

This is a wire-protocol change for any external consumer of \`/status-env\`. The internal client (\`envs/base.py\`) and the test are updated in the same PR. Any external integrator calling \`/status-env\` with a JSON body will need to switch to a query parameter — happy to follow up with a non-breaking transition (option 3 in the issue) if maintainers prefer that path instead.

The on-disk hint that this was non-standard (\`api/README.md:122\`) was already in the codebase — this PR finishes the job.

---

Contributed by [kcolbchain](https://kcolbchain.com).