### PR TITLE
Add shared structured-output parsing helpers and migrate multimodal answer extraction

### DIFF
--- a/atroposlib/tests/test_structured_output.py
+++ b/atroposlib/tests/test_structured_output.py
@@ -1,0 +1,186 @@
+import pytest
+
+from atroposlib.utils.structured_output import (
+    count_tag_occurrences,
+    extract_all_tagged_blocks,
+    extract_boxed,
+    extract_fenced_block,
+    extract_json,
+    extract_tagged,
+    extract_tagged_or_raw,
+    normalize_boxed_answer,
+    safe_json_loads,
+    split_after_think,
+    strip_think_blocks,
+    validate_single_think_block,
+)
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("<think>reasoning</think><answer>42</answer>", True),
+        ("prefix <think>reasoning</think> suffix", True),
+        ("<think>one</think><think>two</think>", False),
+        ("<think>unterminated", False),
+    ],
+)
+def test_validate_single_think_block(text, expected):
+    assert validate_single_think_block(text) is expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        (
+            "<think>reasoning</think><answer>42</answer>",
+            ("<think>reasoning</think>", "<answer>42</answer>"),
+        ),
+        (
+            "intro<think>reasoning</think>tail",
+            ("intro<think>reasoning</think>", "tail"),
+        ),
+        ("<think>missing close", None),
+        ("<think>one</think><think>two</think>", None),
+    ],
+)
+def test_split_after_think(text, expected):
+    assert split_after_think(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("a<think>x</think>b", "ab"),
+        ("<think>x</think><think>y</think>", ""),
+        ("no think here", "no think here"),
+        ("<think>unterminated", "<think>unterminated"),
+    ],
+)
+def test_strip_think_blocks(text, expected):
+    assert strip_think_blocks(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "outside_think_only", "expected"),
+    [
+        ("<answer>1</answer><answer>2</answer>", False, 2),
+        ("<think><answer>x</answer></think><answer>y</answer>", True, 1),
+        ("<think><answer>x</answer></think><answer>y</answer>", False, 2),
+        ("no tags", False, 0),
+    ],
+)
+def test_count_tag_occurrences(text, outside_think_only, expected):
+    assert count_tag_occurrences(text, "answer", outside_think_only) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "kwargs", "expected"),
+    [
+        ("<answer>42</answer>", {}, "42"),
+        (
+            "<think>r</think><answer>42</answer>",
+            {"after_think_only": True},
+            "42",
+        ),
+        (
+            "<answer>1</answer><answer>2</answer>",
+            {"strict_single": True},
+            None,
+        ),
+        ("no tags", {}, None),
+    ],
+)
+def test_extract_tagged(text, kwargs, expected):
+    assert extract_tagged(text, **kwargs) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("<answer>42</answer>", "42"),
+        (" plain text ", "plain text"),
+        ("<answer>1</answer><answer>2</answer>", "1"),
+        ("", ""),
+    ],
+)
+def test_extract_tagged_or_raw(text, expected):
+    assert extract_tagged_or_raw(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("<tool_call>a</tool_call><tool_call>b</tool_call>", ["a", "b"]),
+        ("<tool_call> one </tool_call>", ["one"]),
+        ("no tags", []),
+        ("<tool_call>missing close", []),
+    ],
+)
+def test_extract_all_tagged_blocks(text, expected):
+    assert extract_all_tagged_blocks(text, "tool_call") == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "strict_single", "expected"),
+    [
+        ("answer is \\boxed{42}", False, "42"),
+        ("nested \\boxed{a^{2}} done", False, "a^{2}"),
+        ("\\boxed{1} and \\boxed{2}", True, None),
+        ("no box", False, None),
+    ],
+)
+def test_extract_boxed(text, strict_single, expected):
+    assert extract_boxed(text, strict_single=strict_single) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("\\boxed{42}", "42"),
+        (" result \\boxed{a^{2}} ", "a^{2}"),
+        ("plain answer", "plain answer"),
+        ("", ""),
+    ],
+)
+def test_normalize_boxed_answer(text, expected):
+    assert normalize_boxed_answer(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ('{"a": 1}', {"a": 1}),
+        (" [1, 2] ", [1, 2]),
+        ("not json", None),
+        ('{"a": }', None),
+    ],
+)
+def test_safe_json_loads(text, expected):
+    assert safe_json_loads(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ('prefix {"a": [1, 2]} suffix', {"a": [1, 2]}),
+        ('noise ["x", {"y": 2}] tail', ["x", {"y": 2}]),
+        ('text {"a":"}"} end', {"a": "}"}),
+        ("no json here", None),
+    ],
+)
+def test_extract_json(text, expected):
+    assert extract_json(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "language", "expected"),
+    [
+        ("```json\n{\"a\":1}\n```", "json", '{"a":1}'),
+        ("```python\nprint(1)\n```", None, "print(1)"),
+        ("```txt\nhello\n```", "json", None),
+        ("```python\nunterminated", "python", None),
+    ],
+)
+def test_extract_fenced_block(text, language, expected):
+    assert extract_fenced_block(text, language=language) == expected

--- a/atroposlib/tests/test_structured_output.py
+++ b/atroposlib/tests/test_structured_output.py
@@ -176,7 +176,7 @@ def test_extract_json(text, expected):
 @pytest.mark.parametrize(
     ("text", "language", "expected"),
     [
-        ("```json\n{\"a\":1}\n```", "json", '{"a":1}'),
+        ('```json\n{"a":1}\n```', "json", '{"a":1}'),
         ("```python\nprint(1)\n```", None, "print(1)"),
         ("```txt\nhello\n```", "json", None),
         ("```python\nunterminated", "python", None),

--- a/atroposlib/utils/structured_output.py
+++ b/atroposlib/utils/structured_output.py
@@ -1,0 +1,266 @@
+"""Pure text, tag, and JSON parsing helpers for environment outputs."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+THINK_BLOCK_PATTERN = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
+BOXED_PATTERN = re.compile(r"\\boxed\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}")
+
+
+def validate_single_think_block(text: str) -> bool:
+    """Return True when text contains exactly one well-formed ``<think>`` block.
+
+    A valid block requires exactly one opening tag, exactly one closing tag, and a
+    complete ``<think>...</think>`` span. Non-string inputs are treated as invalid.
+    """
+
+    if not isinstance(text, str):
+        return False
+
+    open_count = len(re.findall(r"<think>", text, re.IGNORECASE))
+    close_count = len(re.findall(r"</think>", text, re.IGNORECASE))
+    if open_count != 1 or close_count != 1:
+        return False
+
+    match = THINK_BLOCK_PATTERN.search(text)
+    return match is not None
+
+
+def split_after_think(text: str) -> tuple[str, str] | None:
+    """Split text into ``(prefix_through_think_block, suffix_after_think)``.
+
+    Returns ``None`` when there is not exactly one valid ``<think>`` block. The
+    first element preserves any text before the opening ``<think>`` tag and
+    includes the closing ``</think>`` tag.
+    """
+
+    if not validate_single_think_block(text):
+        return None
+
+    match = THINK_BLOCK_PATTERN.search(text)
+    if match is None:
+        return None
+
+    return text[: match.end()], text[match.end() :]
+
+
+def strip_think_blocks(text: str) -> str:
+    """Remove all complete ``<think>...</think>`` blocks from text.
+
+    Returns the original value for non-string input converted to ``str``. Incomplete
+    think tags are left untouched because there is no complete block to strip.
+    """
+
+    if not isinstance(text, str):
+        return str(text)
+    return THINK_BLOCK_PATTERN.sub("", text)
+
+
+def count_tag_occurrences(text: str, tag: str, outside_think_only: bool = False) -> int:
+    """Count complete occurrences of a tag pair like ``<answer>...</answer>``.
+
+    If ``outside_think_only`` is True, complete think blocks are removed before
+    counting. Blank tag names return ``0``.
+    """
+
+    if not isinstance(text, str) or not tag:
+        return 0
+
+    haystack = strip_think_blocks(text) if outside_think_only else text
+    pattern = re.compile(
+        rf"<{re.escape(tag)}\b[^>]*>.*?</{re.escape(tag)}>",
+        re.DOTALL | re.IGNORECASE,
+    )
+    return len(pattern.findall(haystack))
+
+
+def extract_tagged(
+    text: str,
+    tag: str = "answer",
+    strict_single: bool = False,
+    after_think_only: bool = False,
+) -> str | None:
+    """Extract content from the first matching tag block.
+
+    Returns the inner text of ``<tag>...</tag>`` with surrounding whitespace
+    stripped. If ``strict_single`` is True, exactly one matching block must exist.
+    If ``after_think_only`` is True, extraction happens only on the text after a
+    valid single think block; otherwise ``None`` is returned.
+    """
+
+    if not isinstance(text, str) or not tag:
+        return None
+
+    haystack = text
+    if after_think_only:
+        parts = split_after_think(text)
+        if parts is None:
+            return None
+        haystack = parts[1]
+
+    pattern = re.compile(
+        rf"<{re.escape(tag)}\b[^>]*>(.*?)</{re.escape(tag)}>",
+        re.DOTALL | re.IGNORECASE,
+    )
+    matches = pattern.findall(haystack)
+    if not matches:
+        return None
+    if strict_single and len(matches) != 1:
+        return None
+    return matches[0].strip()
+
+
+def extract_tagged_or_raw(text: str, tag: str = "answer") -> str:
+    """Extract tagged content when present, otherwise return stripped raw text.
+
+    Missing tags, malformed tags, or non-string values fall back to ``str(value)``
+    with leading/trailing whitespace removed.
+    """
+
+    extracted = extract_tagged(text, tag=tag, strict_single=False, after_think_only=False)
+    if extracted is not None:
+        return extracted
+    return text.strip() if isinstance(text, str) else str(text).strip()
+
+
+def extract_all_tagged_blocks(text: str, tag: str) -> list[str]:
+    """Return all inner contents for matching tag blocks.
+
+    The returned list preserves source order and strips surrounding whitespace from
+    each captured block. Invalid inputs return an empty list.
+    """
+
+    if not isinstance(text, str) or not tag:
+        return []
+
+    pattern = re.compile(
+        rf"<{re.escape(tag)}\b[^>]*>(.*?)</{re.escape(tag)}>",
+        re.DOTALL | re.IGNORECASE,
+    )
+    return [match.strip() for match in pattern.findall(text)]
+
+
+def extract_boxed(text: str, strict_single: bool = False) -> str | None:
+    """Extract the content of the first ``\\boxed{...}`` expression.
+
+    Nested braces inside the boxed content are supported. If ``strict_single`` is
+    True, exactly one boxed expression must be present. Returns ``None`` when no
+    complete boxed span is found.
+    """
+
+    if not isinstance(text, str):
+        return None
+
+    matches = BOXED_PATTERN.findall(text)
+    if not matches:
+        return None
+    if strict_single and len(matches) != 1:
+        return None
+    return matches[0].strip()
+
+
+def normalize_boxed_answer(text: str) -> str:
+    """Return the first boxed payload when present, otherwise stripped text.
+
+    This helper is intentionally shallow: it removes a single outer ``\\boxed{}``
+    wrapper but does not perform mathematical normalization or semantic checking.
+    """
+
+    if not isinstance(text, str):
+        return str(text).strip()
+
+    extracted = extract_boxed(text, strict_single=False)
+    return extracted if extracted is not None else text.strip()
+
+
+def safe_json_loads(text: str) -> Any | None:
+    """Parse JSON and return ``None`` instead of raising on malformed input.
+
+    Non-string inputs return ``None``. Leading and trailing whitespace are ignored.
+    """
+
+    if not isinstance(text, str):
+        return None
+    try:
+        return json.loads(text.strip())
+    except (TypeError, json.JSONDecodeError, ValueError):
+        return None
+
+
+def extract_json(text: str) -> dict | list | None:
+    """Extract and parse the first top-level JSON object or array from text.
+
+    The scan is quote-aware, so braces or brackets inside JSON strings do not break
+    matching. Returns only ``dict`` or ``list`` results; scalar JSON values are
+    treated as unsupported and return ``None``.
+    """
+
+    if not isinstance(text, str):
+        return None
+
+    start_positions = [
+        (idx, char) for idx, char in enumerate(text) if char in "{["
+    ]
+    for start_idx, start_char in start_positions:
+        end_char = "}" if start_char == "{" else "]"
+        depth = 0
+        in_string = False
+        escape = False
+
+        for idx in range(start_idx, len(text)):
+            char = text[idx]
+
+            if in_string:
+                if escape:
+                    escape = False
+                elif char == "\\":
+                    escape = True
+                elif char == '"':
+                    in_string = False
+                continue
+
+            if char == '"':
+                in_string = True
+                continue
+
+            if char == start_char:
+                depth += 1
+            elif char == end_char:
+                depth -= 1
+                if depth == 0:
+                    candidate = text[start_idx : idx + 1]
+                    parsed = safe_json_loads(candidate)
+                    if isinstance(parsed, (dict, list)):
+                        return parsed
+                    break
+
+    return None
+
+
+def extract_fenced_block(text: str, language: str | None = None) -> str | None:
+    """Extract the first fenced code block from Markdown-like text.
+
+    If ``language`` is provided, only fences with that language label are matched.
+    The returned content excludes the backticks and preserves internal newlines.
+    Returns ``None`` for malformed or absent fences.
+    """
+
+    if not isinstance(text, str):
+        return None
+
+    if language is None:
+        pattern = re.compile(r"```[^\n]*\n(.*?)\n```", re.DOTALL)
+    else:
+        pattern = re.compile(
+            rf"```{re.escape(language)}[^\n]*\n(.*?)\n```",
+            re.DOTALL | re.IGNORECASE,
+        )
+
+    match = pattern.search(text)
+    if match is None:
+        return None
+    return match.group(1)

--- a/atroposlib/utils/structured_output.py
+++ b/atroposlib/utils/structured_output.py
@@ -6,7 +6,6 @@ import json
 import re
 from typing import Any
 
-
 THINK_BLOCK_PATTERN = re.compile(r"<think>.*?</think>", re.DOTALL | re.IGNORECASE)
 BOXED_PATTERN = re.compile(r"\\boxed\{([^{}]*(?:\{[^{}]*\}[^{}]*)*)\}")
 
@@ -121,7 +120,9 @@ def extract_tagged_or_raw(text: str, tag: str = "answer") -> str:
     with leading/trailing whitespace removed.
     """
 
-    extracted = extract_tagged(text, tag=tag, strict_single=False, after_think_only=False)
+    extracted = extract_tagged(
+        text, tag=tag, strict_single=False, after_think_only=False
+    )
     if extracted is not None:
         return extracted
     return text.strip() if isinstance(text, str) else str(text).strip()
@@ -202,9 +203,7 @@ def extract_json(text: str) -> dict | list | None:
     if not isinstance(text, str):
         return None
 
-    start_positions = [
-        (idx, char) for idx, char in enumerate(text) if char in "{["
-    ]
+    start_positions = [(idx, char) for idx, char in enumerate(text) if char in "{["]
     for start_idx, start_char in start_positions:
         end_char = "}" if start_char == "{" else "]"
         depth = 0

--- a/environments/multimodal_dpo/ocr_vqa.py
+++ b/environments/multimodal_dpo/ocr_vqa.py
@@ -1,7 +1,6 @@
 import base64
 import io
 import random
-import re
 import traceback
 from typing import List, Optional, Tuple
 
@@ -14,6 +13,7 @@ from atroposlib.envs.base import (
     ScoredDataGroup,
 )
 from atroposlib.type_definitions import GameHistory, Item
+from atroposlib.utils.structured_output import extract_tagged_or_raw
 from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
 
 
@@ -135,12 +135,10 @@ class OcrVqaEnv(BaseEnv):
             # Extract model and gold answers
             try:
                 reply = item[0][-1]["content"]
-                m = re.search(r"<answer>\s*(.*?)\s*</answer>", reply, re.IGNORECASE)
-                model_answer = m.group(1).strip() if m else reply.strip()
+                model_answer = extract_tagged_or_raw(reply, tag="answer")
 
                 gold = item[1]
-                g = re.search(r"<answer>\s*(.*?)\s*</answer>", gold, re.IGNORECASE)
-                gold_answer = g.group(1).strip() if g else gold.strip()
+                gold_answer = extract_tagged_or_raw(gold, tag="answer")
 
                 reward = model_answer.lower() == gold_answer.lower()
             except Exception:

--- a/environments/multimodal_dpo/pixmo_clocks.py
+++ b/environments/multimodal_dpo/pixmo_clocks.py
@@ -1,7 +1,6 @@
 import base64
 import io
 import random
-import re
 import traceback
 from typing import List, Optional, Tuple
 
@@ -14,6 +13,7 @@ from atroposlib.envs.base import (
     ScoredDataGroup,
 )
 from atroposlib.type_definitions import GameHistory, Item
+from atroposlib.utils.structured_output import extract_tagged_or_raw
 from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
 
 
@@ -137,16 +137,10 @@ class ClockDatasetEnv(BaseEnv):
             # Extract answers
             try:
                 reply = item[0][-1]["content"]
-                m_match = re.search(
-                    r"<answer>\s*(.*?)\s*</answer>", reply, re.IGNORECASE
-                )
-                model_answer = m_match.group(1).strip() if m_match else reply.strip()
+                model_answer = extract_tagged_or_raw(reply, tag="answer")
 
                 gold = item[1]
-                g_match = re.search(
-                    r"<answer>\s*(.*?)\s*</answer>", gold, re.IGNORECASE
-                )
-                gold_answer = g_match.group(1).strip() if g_match else gold.strip()
+                gold_answer = extract_tagged_or_raw(gold, tag="answer")
 
                 reward = model_answer == gold_answer
             except Exception:

--- a/environments/multimodal_dpo/pixmo_count.py
+++ b/environments/multimodal_dpo/pixmo_count.py
@@ -1,7 +1,6 @@
 import base64
 import io
 import random
-import re
 import traceback
 from typing import List, Optional, Tuple
 
@@ -16,6 +15,7 @@ from atroposlib.envs.base import (
     ScoredDataGroup,
 )
 from atroposlib.type_definitions import GameHistory, Item
+from atroposlib.utils.structured_output import extract_tagged_or_raw
 from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
 
 
@@ -128,12 +128,10 @@ class PixmoCountEnv(BaseEnv):
 
             try:
                 reply = item[0][-1]["content"]
-                m = re.search(r"<answer>\s*(.*?)\s*</answer>", reply, re.IGNORECASE)
-                model_answer = m.group(1).strip() if m else reply.strip()
+                model_answer = extract_tagged_or_raw(reply, tag="answer")
 
                 gold = item[1]
-                g = re.search(r"<answer>\s*(.*?)\s*</answer>", gold, re.IGNORECASE)
-                gold_answer = g.group(1).strip() if g else gold.strip()
+                gold_answer = extract_tagged_or_raw(gold, tag="answer")
 
                 reward = model_answer.lower() == gold_answer.lower()
             except Exception:


### PR DESCRIPTION
 ## PR Type
  - [ ] RL Environment PR - Complete Environment Snapshot & Zero-Training sections
  - [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

  ## 📝 General Information
  ### Description
  This PR adds a small stdlib-only shared parsing helper for common structured-output patterns and migrates three low-risk multimodal environments to use it for `<answer>...</answer>` extraction.

  Added:
  - `atroposlib/utils/structured_output.py`
  - `atroposlib/tests/test_structured_output.py`

  Migrated call sites:
  - `environments/multimodal_dpo/pixmo_clocks.py`
  - `environments/multimodal_dpo/pixmo_count.py`
  - `environments/multimodal_dpo/ocr_vqa.py`

  The helper covers:
  - validating a single `<think>...</think>` block
  - splitting content after a think block
  - stripping think blocks
  - counting tagged blocks
  - extracting tagged content such as `<answer>...</answer>`
  - extracting all tagged blocks
  - extracting and normalizing `\boxed{...}` answers
  - safe JSON parsing and first JSON object/list extraction
  - fenced code block extraction

  This PR intentionally does not change math-specific verification or broader environment-specific scoring logic.

  ### Related Issues
  No linked issue.

  ### Type of Change
  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] This change requires a documentation update
  - [x] Code refactor (no functional changes)
  - [ ] Build/CI/CD related changes
  - [ ] Other (please describe):

  ## ✅ Developer & Reviewer Checklist
  - [ ] Code follows project style (black, isort, flake8 pass with pre-commit)
  - [x] I have performed a self-review of my own code
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [ ] My changes generate no new warnings
  - [x] New and existing unit tests pass locally with my changes
  - [x] Docstrings added for all new public classes / functions
  - [ ] If .env vars required, did you add it to the .env.example in repo root?

