### PR TITLE
fix(submodule): mark bleuberi as update=none so recursive init doesn't break installs

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,4 @@
 [submodule "environments/community/bleuberi/bleuberi-repo"]
 	path = environments/community/bleuberi/bleuberi-repo
 	url = https://github.com/lilakk/BLEUBERI.git
+	update = none

--- a/environments/community/bleuberi/README.md
+++ b/environments/community/bleuberi/README.md
@@ -12,11 +12,28 @@ BLEUBERI uses BLEU scores (a simple n-gram matching metric) directly as rewards 
 
 ## Installation
 
-Before using the BLEUBERI environment, you need to install its dependencies:
+The BLEUBERI environment depends on a git submodule (`bleuberi-repo`, mirroring [lilakk/BLEUBERI](https://github.com/lilakk/BLEUBERI)) and a few Python packages.
+
+### 1. Initialize the submodule (opt-in)
+
+The submodule is configured with `update = none` so that the top-level `git submodule update --init --recursive` (and `uv pip install` from git) does **not** auto-clone it. This keeps the rest of Atropos installable for users who don't need BLEUBERI.
+
+To use this environment, fetch the submodule explicitly:
 
 ```bash
-# Install the required dependencies
-pip install -r environments/bleuberi/requirements.txt
+git submodule update --init environments/community/bleuberi/bleuberi-repo
+```
+
+> **Note on LFS:** the upstream BLEUBERI repository tracks evaluation data under `arena_analysis/` with Git LFS. If you hit `batch response: This repository exceeded its LFS budget` (see [#448](https://github.com/NousResearch/atropos/issues/448)) and do not need those evaluation files for training, skip the LFS smudge:
+>
+> ```bash
+> GIT_LFS_SKIP_SMUDGE=1 git submodule update --init environments/community/bleuberi/bleuberi-repo
+> ```
+
+### 2. Install Python dependencies
+
+```bash
+pip install -r environments/community/bleuberi/requirements.txt
 ```
 
 The key dependencies include:

--- a/environments/community/bleuberi/bleuberi_env.py
+++ b/environments/community/bleuberi/bleuberi_env.py
@@ -43,10 +43,22 @@ class BLEUBERIItem(TypedDict):
     metadata: Dict[str, Any]
 
 
-# Add the BLEUBERI repository to the Python path
+# Add the BLEUBERI repository to the Python path. The submodule is configured
+# `update = none` in .gitmodules so it isn't auto-fetched by recursive submodule
+# init — see this directory's README for the explicit init command.
 _SUBMODULE_DIR = os.path.abspath(
     os.path.join(os.path.dirname(__file__), "bleuberi-repo")
 )
+if not os.path.isdir(os.path.join(_SUBMODULE_DIR, "training")):
+    raise RuntimeError(
+        "BLEUBERI submodule not initialized at "
+        f"{_SUBMODULE_DIR}. Run:\n\n"
+        "    git submodule update --init "
+        "environments/community/bleuberi/bleuberi-repo\n\n"
+        "If the upstream repo's LFS budget is exhausted and you don't need "
+        "the eval data, prefix with GIT_LFS_SKIP_SMUDGE=1. See "
+        "environments/community/bleuberi/README.md for details."
+    )
 if _SUBMODULE_DIR not in sys.path:
     sys.path.insert(0, _SUBMODULE_DIR)
 


### PR DESCRIPTION
Closes #448.

## Problem

\`pip install\` / \`uv pip install\` of \`atroposlib\` from this repo (for example as a transitive dependency of \`tinker-atropos\`) calls \`git submodule update --recursive --init\`, which currently fails:

\`\`\`
fatal: Unable to checkout '...' in submodule path
'environments/community/bleuberi/bleuberi-repo'
\`\`\`

The root cause is upstream: [lilakk/BLEUBERI](https://github.com/lilakk/BLEUBERI) tracks \`arena_analysis/arena_1k_final/\` with Git LFS, and the upstream LFS budget is exhausted (\`batch response: This repository exceeded its LFS budget\`). The smudge filter hard-fails, taking down submodule checkout — and therefore the entire install — for every new user, regardless of whether they actually want the BLEUBERI environment. See #448 for a full reproducer.

## Fix

Mark only the \`bleuberi-repo\` submodule with \`update = none\` in \`.gitmodules\`. \`git submodule update --init --recursive\` (and tooling that wraps it: uv, pip git installs, \`pre-commit\`'s recursive submodule init) now skip this entry by default. Users who actually want to run \`bleuberi_env.py\` fetch it explicitly:

\`\`\`bash
git submodule update --init environments/community/bleuberi/bleuberi-repo
\`\`\`

…optionally with \`GIT_LFS_SKIP_SMUDGE=1\` to bypass the upstream LFS issue when they don't need the eval data.

The other three submodules (\`internbootcamp_lib\`, \`reasoning-gym\`, \`AI_Diplomacy\`) are unaffected and keep their default behavior — none of them are LFS-bound.

## Why \`update = none\` (vs deleting the submodule)

Keeping the entry registered preserves the pinned commit + URL, so contributors working on BLEUBERI specifically still get reproducible checkouts via the explicit init command. Deleting the submodule would lose that pinning. \`update = none\` is the documented git mechanism for opt-in submodules ([gitmodules(5)](https://git-scm.com/docs/gitmodules#Documentation/gitmodules.txt-submodulenameupdate)).

## Files changed

- **\`.gitmodules\`** — one-line addition (\`update = none\` on the bleuberi entry).
- **\`environments/community/bleuberi/README.md\`** — install section now documents the explicit submodule init step + the \`GIT_LFS_SKIP_SMUDGE=1\` workaround, linking #448.
- **\`environments/community/bleuberi/bleuberi_env.py\`** — if a user imports the env without first initializing the submodule, raise a \`RuntimeError\` with the exact init command, instead of the current opaque \`ModuleNotFoundError: No module named 'training'\`.

## Verification

\`\`\`
$ git config -f .gitmodules --get-regexp '^submodule\.environments/community/bleuberi/bleuberi-repo\..*'
submodule.environments/community/bleuberi/bleuberi-repo.path environments/community/bleuberi/bleuberi-repo
submodule.environments/community/bleuberi/bleuberi-repo.url https://github.com/lilakk/BLEUBERI.git
submodule.environments/community/bleuberi/bleuberi-repo.update none
\`\`\`

\`git submodule update --init --recursive\` from a clean clone of this branch initializes the other three submodules and does not attempt to clone \`bleuberi-repo\`. The explicit \`git submodule update --init environments/community/bleuberi/bleuberi-repo\` still works (and reproduces the upstream LFS error, which is independently addressable on the BLEUBERI side or via \`GIT_LFS_SKIP_SMUDGE=1\`).

\`bleuberi_env.py\` AST-parses; the new \`RuntimeError\` only fires when the submodule directory exists but is empty (the unpopulated git submodule state).