### PR TITLE
fix(docs): correct broken GitHub Flow link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ We welcome any type of contribution, not just code. You can help with:
 We use GitHub to host the code, track issues and feature requests, and accept pull requests.
 
 ## We Use GitHub Flow
-We follow the [GitHub Flow](https://docs.github.com) development workflow. All code changes happen through Pull Requests.
+We follow the [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow) development workflow. All code changes happen through Pull Requests.
 
 ## Getting Started
 


### PR DESCRIPTION
### What
Replace the generic `https://docs.github.com` link with the actual GitHub Flow documentation URL.

### Why
The link currently points to the GitHub Docs homepage rather than the GitHub Flow guide, so readers clicking it land on an unrelated page.

Small, scoped fix from kcolbchain contrib-bot.