### PR TITLE
Stop parse_tool_call from corrupting JSON tool calls that contain apostrophes

### DIFF
--- a/atroposlib/tests/test_tool_call_parser.py
+++ b/atroposlib/tests/test_tool_call_parser.py
@@ -1,0 +1,55 @@
+from atroposlib.utils.tool_call_parser import extract_tool_call, parse_tool_call
+
+TOOLS = [{"name": "web_search"}, {"name": "send_message"}]
+
+
+def test_plain_json_tool_call():
+    resp = '<tool_call>{"name": "web_search", "arguments": {"query": "weather today"}}</tool_call>'
+    name, args, is_error = parse_tool_call(resp, available_tools=TOOLS)
+    assert not is_error
+    assert name == "web_search"
+    assert args == {"query": "weather today"}
+
+
+def test_apostrophe_in_value_is_preserved():
+    # Valid JSON whose string value contains an apostrophe must still parse.
+    resp = '<tool_call>{"name": "web_search", "arguments": {"query": "what\'s the weather"}}</tool_call>'
+    name, args, is_error = parse_tool_call(resp, available_tools=TOOLS)
+    assert not is_error
+    assert name == "web_search"
+    assert args == {"query": "what's the weather"}
+
+
+def test_possessive_in_value_is_preserved():
+    resp = '<tool_call>{"name": "send_message", "arguments": {"text": "the user\'s file is ready"}}</tool_call>'
+    name, args, is_error = parse_tool_call(resp, available_tools=TOOLS)
+    assert not is_error
+    assert args == {"text": "the user's file is ready"}
+
+
+def test_single_quoted_dict_still_parses():
+    # Python-style single-quoted dicts remain supported via the literal-eval fallback.
+    resp = "<tool_call>{'name': 'web_search', 'arguments': {'query': 'weather today'}}</tool_call>"
+    name, args, is_error = parse_tool_call(resp, available_tools=TOOLS)
+    assert not is_error
+    assert name == "web_search"
+    assert args == {"query": "weather today"}
+
+
+def test_unknown_tool_is_error():
+    resp = '<tool_call>{"name": "no_such_tool", "arguments": {}}</tool_call>'
+    name, _, is_error = parse_tool_call(resp, available_tools=TOOLS)
+    assert is_error
+    assert name == "-ERROR-"
+
+
+def test_missing_tool_call_is_error():
+    name, args, is_error = parse_tool_call("just some text", available_tools=TOOLS)
+    assert is_error
+    assert name == "-ERROR-"
+    assert args == {}
+
+
+def test_extract_tool_call_returns_inner_content():
+    assert extract_tool_call("<tool_call>abc</tool_call>") == "abc"
+    assert extract_tool_call("no tags here") is None

--- a/atroposlib/utils/tool_call_parser.py
+++ b/atroposlib/utils/tool_call_parser.py
@@ -2,6 +2,7 @@
 Tool call parser helper for extracting and validating tool calls from LLM responses.
 """
 
+import ast
 import json
 import logging
 import re
@@ -56,10 +57,14 @@ def parse_tool_call(
 
     # Parse JSON
     try:
-        # Handle potential single quotes
-        tool_call_content = tool_call_content.replace("'", '"')
-
-        tool_call = json.loads(tool_call_content, strict=False)
+        try:
+            tool_call = json.loads(tool_call_content, strict=False)
+        except json.JSONDecodeError:
+            # Fall back to a Python-literal parse for single-quoted dicts
+            # (e.g. {'name': ...}). Unlike a blanket "'" -> '"' replacement,
+            # this does not corrupt apostrophes inside string values such as
+            # {"query": "what's the weather"}.
+            tool_call = ast.literal_eval(tool_call_content)
 
         # Extract tool name and arguments
         tool_name = tool_call.get("name", "")


### PR DESCRIPTION
parse_tool_call replaced every single quote with a double quote before calling
json.loads:

    tool_call_content = tool_call_content.replace("'", '"')

The goal was to accept Python-style single-quoted dicts, but it also rewrites
apostrophes inside string values, which breaks valid JSON like
{"query": "what's the weather"}. Those calls then fail to parse and are returned
as "-ERROR-", which tool-use environments score as an invalid action.

This drops the blanket replacement. It parses the content as JSON first and only
falls back to ast.literal_eval when that fails, which still handles single-quoted
dicts without corrupting apostrophes inside values.

Added atroposlib/tests/test_tool_call_parser.py covering plain JSON, apostrophes
and possessives in values, single-quoted dicts, and the existing error paths.

Fixes #478
