### PR TITLE
fix: clamp variance to keep GRPO std real for constant float rewards

### DIFF
--- a/atroposlib/tests/test_advantages.py
+++ b/atroposlib/tests/test_advantages.py
@@ -167,3 +167,26 @@ def test_compute_grpo_process_supervision_advantages_std_tol():
     rewards = [[1, 1, 1]]
     with pytest.raises(ValueError):
         compute_grpo_process_supervision_advantages(rewards)
+
+
+def test_compute_stats_constant_float_variance_non_negative():
+    """Constant float rewards must not yield a negative variance.
+
+    The one-pass variance formula can return a tiny negative value from
+    floating-point cancellation (e.g. [0.1, 0.1, 0.1]); left unclamped this
+    makes ``var ** 0.5`` complex downstream.
+    """
+    stats = compute_stats([0.1, 0.1, 0.1])
+    assert stats["var"] >= 0.0
+    assert isinstance(stats["var"] ** 0.5, float)
+
+
+def test_compute_grpo_process_supervision_advantages_std_tol_float():
+    """Constant *float* rewards hit the collapse path and must raise cleanly.
+
+    Regression test: previously the negative variance produced a complex std,
+    so the ``std < std_tol`` guard raised TypeError instead of ValueError.
+    """
+    rewards = [[0.1, 0.1, 0.1]]
+    with pytest.raises(ValueError):
+        compute_grpo_process_supervision_advantages(rewards)

--- a/atroposlib/utils/advantages.py
+++ b/atroposlib/utils/advantages.py
@@ -99,7 +99,12 @@ def compute_stats(data: Sequence[number | Sequence]) -> dict[str, float]:
         raise ValueError("No numerical elements found in the input data.")
 
     mean = total / count
-    variance = total_sq / count - mean * mean
+    # The one-pass formula (E[x^2] - E[x]^2) is prone to catastrophic
+    # cancellation: for constant float rewards it can return a tiny negative
+    # value instead of exactly 0.0. Clamp to 0 so downstream `var ** 0.5`
+    # stays real (a negative variance yields a complex std, which then breaks
+    # the `std < std_tol` comparison in the GRPO collapse case).
+    variance = max(total_sq / count - mean * mean, 0.0)
     return {"mean": mean, "var": variance}
 
 


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
`compute_stats` (`atroposlib/utils/advantages.py`) computes variance with the one-pass formula `E[x^2] - E[x]^2`, which is prone to catastrophic cancellation. For **constant float** rewards (e.g. `[0.1, 0.1, 0.1]`) it returns a tiny *negative* value instead of `0.0`.

Downstream, `compute_grpo_process_supervision_advantages` does `std = stats["var"] ** 0.5`. A negative variance makes `std` a **complex** number, so the intended collapse guard `if std < std_tol:` raises `TypeError: '<' not supported between instances of 'complex' and 'float'` instead of the documented `ValueError`.

This is the standard GRPO degenerate case (every sample in a group scored equally), which is hit routinely during training whenever rewards are floats.

**Reproduction (before this PR):**
```python
from atroposlib.utils.advantages import compute_grpo_process_supervision_advantages
compute_grpo_process_supervision_advantages([[0.1, 0.1, 0.1]])
# TypeError: '<' not supported between instances of 'complex' and 'float'
```

**Fix:** clamp the variance at `0.0` so `var ** 0.5` stays real and the guard raises the documented `ValueError`.

The existing `test_compute_grpo_process_supervision_advantages_std_tol` only used integer rewards `[[1, 1, 1]]`, where the variance is exactly `0.0`, so it never exercised this path. Added float regression tests.

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)