### PR TITLE
fix: resolve correct reward class for modules defining several rewards

### DIFF
--- a/atroposlib/envs/reward_fns/registry.py
+++ b/atroposlib/envs/reward_fns/registry.py
@@ -1,4 +1,4 @@
-import importlib
+import importlib.util
 import inspect
 import logging
 from pathlib import Path
@@ -174,17 +174,38 @@ class RewardRegistry:
             module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(module)
 
-            # First try to find a class that inherits from RewardFunction
-            for obj_name, obj in inspect.getmembers(module):
-                if (
-                    inspect.isclass(obj)
-                    and issubclass(obj, RewardFunction)
-                    and obj is not RewardFunction
-                ):
-                    # Register the class with the requested name
-                    # This ensures it's accessible by the name the test expects
+            # Importing the module runs its ``@registry.register`` decorators,
+            # which register each class under its own (normalized) name. If that
+            # already registered the requested name, use it directly. Scanning
+            # module members instead would pick the alphabetically-first
+            # RewardFunction subclass, silently shadowing the correct class in
+            # modules that define several rewards (e.g. r1_reward.py defines
+            # AccuracyXReward, FormatReasoningReward and R1Reward).
+            if name in self._registry:
+                return
+
+            # Fallback for legacy modules that don't self-register: find a class
+            # defined in this module. Prefer one whose name matches the request;
+            # otherwise take the first module-defined subclass.
+            fallback = None
+            for obj_name, obj in inspect.getmembers(module, inspect.isclass):
+                if not issubclass(obj, RewardFunction) or obj is RewardFunction:
+                    continue
+                # Skip classes merely imported into the module (e.g. the base
+                # class or rewards pulled in from elsewhere).
+                if obj.__module__ != module.__name__:
+                    continue
+                normalized = obj_name.lower()
+                if normalized.endswith("reward"):
+                    normalized = normalized[:-6]
+                if name in (normalized, obj_name.lower()) or normalized == base_name:
                     self.register_function(name, obj)
                     return
+                if fallback is None:
+                    fallback = obj
+            if fallback is not None:
+                self.register_function(name, fallback)
+                return
 
             # If no class found, look for functions with matching name patterns
             func_patterns = [f"{base_name}", f"{base_name}_reward", "format_reward"]

--- a/atroposlib/tests/test_reward_registry.py
+++ b/atroposlib/tests/test_reward_registry.py
@@ -1,0 +1,24 @@
+"""Tests for the reward-function registry's lazy loader."""
+
+from atroposlib.envs.reward_fns import registry
+
+
+def test_create_resolves_correct_class_in_multiclass_module():
+    """``r1_reward.py`` defines AccuracyXReward, FormatReasoningReward and
+    R1Reward. ``create("r1")`` must return R1Reward, not the alphabetically
+    first subclass in the module.
+    """
+    reward = registry.create("r1")
+    assert type(reward).__name__ == "R1Reward"
+
+
+def test_create_resolves_reward_suffix_alias():
+    """The ``<name>_reward`` alias resolves to the same class."""
+    reward = registry.create("r1_reward")
+    assert type(reward).__name__ == "R1Reward"
+
+
+def test_create_single_class_module_still_works():
+    """A module that defines a single reward class keeps working."""
+    reward = registry.create("reasoning_steps")
+    assert type(reward).__name__ == "ReasoningStepsReward"


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
The reward-function registry's lazy loader (`atroposlib/envs/reward_fns/registry.py`) picked the **first** `RewardFunction` subclass returned by `inspect.getmembers` — which is **alphabetically ordered**. That overwrote the registration the module's `@registry.register` decorators had just performed during `exec_module`.

For modules that define several reward classes this silently resolves to the wrong one. `r1_reward.py` defines `AccuracyXReward`, `FormatReasoningReward` and `R1Reward`, so:

```python
from atroposlib.envs.reward_fns import registry
type(registry.create("r1")).__name__
# before: 'AccuracyXReward'   (expected 'R1Reward')
```

i.e. training silently runs against the wrong reward signal.

**Fix:**
- After `exec_module`, trust the decorator-driven registration when it already covers the requested name; otherwise fall back to scanning classes **defined in that module**, preferring one whose (normalized) name matches the request. Legacy single-class modules keep working via the fallback.
- Import `importlib.util` explicitly. The module calls `importlib.util.spec_from_file_location(...)` / `module_from_spec(...)` but only did `import importlib`; `importlib.util` is a submodule that isn't auto-loaded, so a fresh interpreter raises `AttributeError: module 'importlib' has no attribute 'util'` unless some other import happened to pull it in first.

Added `atroposlib/tests/test_reward_registry.py` covering the multi-class module, the `<name>_reward` alias, and a single-class module.

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)