### PR TITLE
fix: don't truncate trajectory alternatives already at the preserve-minimum

### DIFF
--- a/atroposlib/tests/test_message_history_utils.py
+++ b/atroposlib/tests/test_message_history_utils.py
@@ -1,0 +1,115 @@
+"""Tests for ensure_trajectory_token_limit trajectory truncation."""
+
+from atroposlib.utils import message_history_utils
+from atroposlib.utils.message_history_utils import ensure_trajectory_token_limit
+
+
+def _fake_tokenize_for_trainer(tokenizer, messages, *args, **kwargs):
+    """Deterministic stand-in: token count = sum of each message's ``_ntok``."""
+    tokens, masks = [], []
+    for msg in messages:
+        n = msg.get("_ntok", 10)
+        tokens.extend([1] * n)
+        masks.extend([-100] * n)
+    return {"tokens": tokens, "masks": masks}
+
+
+def _msg(role, ntok, content):
+    return {"role": role, "content": content, "_ntok": ntok}
+
+
+def _make_step(alternatives):
+    return {
+        "seed": 1,
+        "parsed_actions": [0] * len(alternatives),
+        "scores": [0.0] * len(alternatives),
+        "messages": [[m.copy() for m in alt] for alt in alternatives],
+        "tokens": [
+            _fake_tokenize_for_trainer(None, alt)["tokens"] for alt in alternatives
+        ],
+        "masks": [
+            _fake_tokenize_for_trainer(None, alt)["masks"] for alt in alternatives
+        ],
+    }
+
+
+def test_truncation_preserves_minimal_alternative(monkeypatch):
+    """A short alternative already at the preserve-minimum must be left intact
+    when a longer alternative in the same step drives truncation.
+    """
+    monkeypatch.setattr(
+        message_history_utils, "tokenize_for_trainer", _fake_tokenize_for_trainer
+    )
+    long_alt = [
+        _msg("system", 5, "sys"),
+        _msg("environment", 5, "env1"),
+        _msg("agent", 50, "ag1"),
+        _msg("environment", 5, "env2"),
+        _msg("agent", 50, "ag2"),
+    ]  # 115 tokens, over the limit
+    minimal_alt = [
+        _msg("system", 5, "sys"),
+        _msg("environment", 5, "env"),
+        _msg("assistant", 10, "keep-me"),
+    ]  # 20 tokens, under the limit and already at the preserve-minimum
+
+    result = ensure_trajectory_token_limit(
+        [_make_step([long_alt, minimal_alt])],
+        tokenizer=None,
+        max_trajectory_tokens=60,
+    )
+
+    assert len(result) == 1
+    kept_minimal = result[0]["messages"][1]
+    assert [m["role"] for m in kept_minimal] == [
+        "system",
+        "environment",
+        "assistant",
+    ]
+    assert kept_minimal[-1]["content"] == "keep-me"
+    # tokens/masks stay consistent with the (untouched) messages.
+    assert len(result[0]["tokens"][1]) == 20
+    # the long alternative is still truncated to fit the limit.
+    assert len(result[0]["tokens"][0]) <= 60
+
+
+def test_truncation_keeps_all_alternatives_within_limit(monkeypatch):
+    """With several alternatives of different lengths, each is truncated only
+    as much as its own budget allows and all end up within the limit.
+    """
+    monkeypatch.setattr(
+        message_history_utils, "tokenize_for_trainer", _fake_tokenize_for_trainer
+    )
+    alternatives = [
+        [
+            _msg("system", 5, "s"),
+            _msg("environment", 5, "e"),
+            _msg("agent", 40, "a"),
+            _msg("environment", 5, "e"),
+            _msg("agent", 40, "a"),
+            _msg("environment", 5, "e"),
+            _msg("agent", 40, "a"),
+        ],
+        [
+            _msg("system", 5, "s"),
+            _msg("environment", 5, "e"),
+            _msg("agent", 30, "a"),
+            _msg("environment", 5, "e"),
+            _msg("agent", 30, "a"),
+        ],
+        [
+            _msg("system", 5, "s"),
+            _msg("environment", 5, "e"),
+            _msg("assistant", 8, "keep"),
+        ],
+    ]
+
+    result = ensure_trajectory_token_limit(
+        [_make_step(alternatives)], tokenizer=None, max_trajectory_tokens=60
+    )
+
+    assert len(result) == 1
+    for alt_tokens in result[0]["tokens"]:
+        assert len(alt_tokens) <= 60
+    # the already-minimal alternative kept its assistant turn.
+    assert result[0]["messages"][2][-1]["content"] == "keep"

--- a/atroposlib/utils/message_history_utils.py
+++ b/atroposlib/utils/message_history_utils.py
@@ -275,7 +275,20 @@ def ensure_trajectory_token_limit(
             max_tokens_after_this_trunc = 0
 
             for alt_idx in range(num_alternatives):
-                for _ in range(min_pop_this_round):
+                # Cap each alternative's pops by its own budget. Alternatives
+                # already at the preserve-minimum report a target of 0 and must
+                # not be popped; popping them anyway destroys the
+                # environment/agent turns this function promises to keep (and
+                # can shrink a short alternative down to just [system], which
+                # then either corrupts its loss mask or, on a later round,
+                # triggers the "list too short" error that discards the whole
+                # step). Any alternative that can be truncated still pops the
+                # full min_pop_this_round, since that is the minimum positive
+                # target.
+                pops_this_alt = min(
+                    min_pop_this_round, target_pop_counts_per_alt[alt_idx]
+                )
+                for _ in range(pops_this_alt):
                     if len(working_messages[alt_idx]) > 1:
                         working_messages[alt_idx].pop(1)
                     else:


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
`ensure_trajectory_token_limit` (`atroposlib/utils/message_history_utils.py`) truncates over-long steps by popping old messages from every alternative in a `ScoredDataGroup`. It first computes a **per-alternative** pop budget, `target_pop_counts_per_alt`, where a budget of `0` means that alternative is already reduced to the preserved messages (`[system, environment, agent]`) and **must not be popped**.

The truncation loop then ignored that budget and popped `min_pop_this_round` messages from **every** alternative unconditionally:

```python
for alt_idx in range(num_alternatives):
    for _ in range(min_pop_this_round):        # applied to ALL alts, incl. budget 0
        if len(working_messages[alt_idx]) > 1:
            working_messages[alt_idx].pop(1)
```

Alternatives shorter than the one driving truncation — normal in multi-turn/multi-step agent envs where rollouts terminate at different depths — are over-truncated. A compliant `[system, environment, assistant]` rollout gets stripped down to `[system]`, destroying the environment observation and the assistant turn the function explicitly promises to preserve. Two concrete failure modes:

1. **Silent label corruption** — the step is kept, but the over-truncated alternative is now `[system]`, so its re-tokenized loss mask ends up training on the system prompt instead of the assistant response.
2. **Whole-step loss** — on a later round the over-truncated alternative hits the `len == 1` "list too short" guard, sets `retokenization_error_this_step = True`, and the **entire step is discarded**, throwing away the salvageable long alternatives too.

**Reproduction (before this PR):** a step with a long alternative (over the limit) and a minimal `[system, environment, assistant]` alternative (under the limit) — the minimal one comes back as `[system]`.

**Fix:** cap each alternative's pops by its own budget (`min(min_pop_this_round, target_pop_counts_per_alt[alt_idx])`). Alternatives at the preserve-minimum pop nothing; any alternative that can still be truncated pops the full `min_pop_this_round` (which is the minimum positive target, so uniform truncation among truncatable alternatives is preserved). When nothing can be reduced further the existing `positive_pop_counts` empty-`break` still discards genuinely-too-long steps.

Added `atroposlib/tests/test_message_history_utils.py` (uses a lightweight stub tokenizer via `monkeypatch`, no model download).

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)