### PR TITLE
fix: don't let response-body read mask the original HTTP error

### DIFF
--- a/atroposlib/tests/test_io.py
+++ b/atroposlib/tests/test_io.py
@@ -1,0 +1,63 @@
+"""Tests for parse_http_response error handling."""
+
+import logging
+
+import pytest
+
+from atroposlib.utils.io import parse_http_response
+
+
+class _FakeHTTPError(Exception):
+    """Stand-in for aiohttp.ClientResponseError (has .status/.message)."""
+
+    def __init__(self, status, message):
+        super().__init__(message)
+        self.status = status
+        self.message = message
+
+
+class _FakeResponse:
+    def __init__(self, status, body=None, text_exc=None):
+        self._status = status
+        self._body = body
+        self._text_exc = text_exc
+
+    def raise_for_status(self):
+        if self._status >= 400:
+            raise _FakeHTTPError(self._status, "Server Error")
+
+    async def json(self):
+        return {"ok": True}
+
+    async def text(self):
+        if self._text_exc is not None:
+            raise self._text_exc
+        return self._body
+
+
+async def test_parse_http_response_success():
+    resp = _FakeResponse(200)
+    assert await parse_http_response(resp) == {"ok": True}
+
+
+async def test_parse_http_response_logs_body_and_reraises_original(caplog):
+    resp = _FakeResponse(500, body="boom detail")
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(_FakeHTTPError) as exc_info:
+            await parse_http_response(resp)
+    assert exc_info.value.status == 500
+    assert "boom detail" in caplog.text
+
+
+async def test_parse_http_response_reraises_original_when_body_read_fails(caplog):
+    """If reading the body fails (e.g. connection released by
+    raise_for_status), the original HTTP error must still propagate and the
+    error must still be logged.
+    """
+    resp = _FakeResponse(503, text_exc=RuntimeError("Connection closed"))
+    with caplog.at_level(logging.ERROR):
+        with pytest.raises(_FakeHTTPError) as exc_info:
+            await parse_http_response(resp)
+    assert exc_info.value.status == 503
+    assert "Status: 503" in caplog.text
+    assert "<response body unavailable>" in caplog.text

--- a/atroposlib/utils/io.py
+++ b/atroposlib/utils/io.py
@@ -30,10 +30,19 @@ async def parse_http_response(
         return await resp.json()
     except Exception as e:
         # Handle HTTP errors (raised by raise_for_status)
-        error_text = await resp.text()  # Read the response text for logging
+        try:
+            # Reading the body for logging can itself fail: raise_for_status()
+            # releases the connection before raising, so on a large/streamed or
+            # interrupted error response resp.text() raises (e.g.
+            # ClientPayloadError/ClientConnectionError). Left unguarded it runs
+            # before logger.error and replaces the original error, dropping the
+            # log line and hiding the HTTP status from status-based retries.
+            error_text = await resp.text()
+        except Exception:
+            error_text = "<response body unavailable>"
         logger.error(
             f"Error fetching from server. Status: {getattr(e, 'status', 'unknown')}, "
             f"Message: {getattr(e, 'message', str(e))}. Response: {error_text}"
         )
-        # Re-raise the exception to allow retry decorators to handle it
+        # Re-raise the original exception to allow retry decorators to handle it
         raise


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
In `parse_http_response` (`atroposlib/utils/io.py`) the error branch reads the response body for logging **after** `resp.raise_for_status()`:

```python
except Exception as e:
    error_text = await resp.text()   # runs after raise_for_status()
    logger.error(...)
    raise
```

aiohttp's `raise_for_status()` calls `release()` on the connection before raising. On a small, fully-buffered error body this is fine, but on a **large / streamed / interrupted** error response `await resp.text()` then raises itself (`ClientPayloadError` / `ClientConnectionError`). Because that read is unguarded:

1. it runs **before** `logger.error(...)`, so the diagnostic log line is never emitted; and
2. it **replaces** the original `ClientResponseError` — which has no `.status` — so retry/backoff decorators that key on the HTTP status no longer see it.

**Reproduction (before this PR)** — a local aiohttp server returning `500` with a large body that closes mid-stream: `parse_http_response` propagates `ClientPayloadError` (no `.status`) and logs nothing, instead of the original `ClientResponseError(status=500)`. All production callers use a plain `aiohttp.ClientSession()` (e.g. `atroposlib/envs/base.py:479`), so this path is live.

**Fix:** guard the body read and fall back to `"<response body unavailable>"`, so the error is always logged and the original exception is always re-raised (bare `raise` preserves it).

Added `atroposlib/tests/test_io.py` covering success, the normal error path (body logged), and the body-read-fails path (original error still propagates + still logged). The last test fails on the previous code.

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)