### PR TITLE
fix: apply sub-reward weights in CombinedReward

### DIFF
--- a/atroposlib/envs/reward_fns/combined_reward.py
+++ b/atroposlib/envs/reward_fns/combined_reward.py
@@ -66,9 +66,14 @@ class CombinedReward(RewardFunction):
                 rewards = reward_fn.compute(completions, **kwargs)
                 all_rewards.append(rewards)
 
-                # Add to combined total (pre-normalization)
+                # Add to combined total (pre-normalization), applying each
+                # sub-reward's weight. compute() returns the *unweighted*
+                # scores (weighting lives in RewardFunction.__call__), so
+                # without this the configured per-reward weights had no effect
+                # in "none"/"minmax" mode and were only (incorrectly) applied to
+                # the denominator in "sum" mode.
                 for i, r in enumerate(rewards):
-                    combined_rewards[i] += r
+                    combined_rewards[i] += r * reward_fn.weight
             except Exception as e:
                 logger.error(f"Error computing reward for {reward_fn.name}: {e}")
                 logger.exception(e)

--- a/atroposlib/tests/test_combined_reward.py
+++ b/atroposlib/tests/test_combined_reward.py
@@ -1,0 +1,33 @@
+"""Tests that CombinedReward applies each sub-reward's weight."""
+
+from atroposlib.envs.reward_fns.combined_reward import CombinedReward
+from atroposlib.envs.reward_fns.reward_function import RewardFunction
+
+
+class _Const(RewardFunction):
+    def __init__(self, value, weight):
+        super().__init__(weight=weight)
+        self._value = value
+
+    def compute(self, completions, **kwargs):
+        return [self._value] * len(completions)
+
+
+def _combined(normalization):
+    # Construct directly with controlled sub-rewards (values 1.0 @ w=1 and
+    # 0.5 @ w=3) instead of going through the registry.
+    cr = CombinedReward.__new__(CombinedReward)
+    RewardFunction.__init__(cr, weight=1.0)
+    cr.normalization = normalization
+    cr.reward_functions = [_Const(1.0, 1.0), _Const(0.5, 3.0)]
+    return cr
+
+
+def test_combined_reward_weighted_sum_none():
+    # normalization="none" -> weighted sum: 1*1.0 + 3*0.5 = 2.5
+    assert _combined("none").compute(["x"]) == [2.5]
+
+
+def test_combined_reward_weighted_average_sum():
+    # normalization="sum" -> weighted average: (1*1.0 + 3*0.5) / (1 + 3) = 0.625
+    assert _combined("sum").compute(["x"]) == [0.625]


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
`CombinedReward.compute` (`atroposlib/envs/reward_fns/combined_reward.py`) accumulated sub-rewards via `reward_fn.compute(completions, **kwargs)`. `compute()` returns the **unweighted** scores — weighting is applied in the base class `RewardFunction.__call__` (`r * self.weight`). So each sub-reward's `weight` was ignored in the numerator:

- `normalization="none"` (the **default**): weights have no effect at all.
- `normalization="sum"`: `total_weight = sum(weights)` appears only in the denominator, giving `Σr / Σw` — neither a sum, a mean, nor the correct weighted average `Σ(w·r) / Σw`.

**Example** — two sub-rewards, `1.0` (weight 1) and `0.5` (weight 3), one completion:

| mode | before | after (correct) |
|------|--------|-----------------|
| `none` | `1.5` (unweighted sum) | `2.5` (weighted sum) |
| `sum`  | `0.375` | `0.625` (weighted average) |

**Fix:** apply `reward_fn.weight` when accumulating each sub-reward. (Kept the existing per-sub-reward `try/except` and did not switch to `__call__` to avoid changing exception/wandb-logging semantics.)

Added `atroposlib/tests/test_combined_reward.py` (both modes); both tests fail on the previous code.

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)