### PR TITLE
fix: avoid duplicate request for n=1 when the API ignores n

### DIFF
--- a/atroposlib/envs/server_handling/openai_server.py
+++ b/atroposlib/envs/server_handling/openai_server.py
@@ -76,8 +76,6 @@ class OpenAIServer(APIServer):
             if n > 1:
                 for c in completion_list[1:]:
                     completions.choices.extend(c.choices)
-            else:
-                completions = await self.openai.chat.completions.create(**kwargs)
         else:
             if "n" in kwargs:
                 n = kwargs["n"]

--- a/atroposlib/tests/test_openai_server.py
+++ b/atroposlib/tests/test_openai_server.py
@@ -1,0 +1,48 @@
+"""Tests for OpenAIServer._chat_completion_wrapper request fan-out."""
+
+import types
+
+from atroposlib.envs.server_handling.openai_server import OpenAIServer
+
+
+class _FakeCompletion:
+    def __init__(self):
+        self.choices = [object()]
+
+
+class _CountingCreate:
+    def __init__(self):
+        self.calls = 0
+
+    async def __call__(self, **kwargs):
+        self.calls += 1
+        return _FakeCompletion()
+
+
+def _fake_server(create, n_kwarg_is_ignored=True):
+    server = types.SimpleNamespace()
+    server.config = types.SimpleNamespace(n_kwarg_is_ignored=n_kwarg_is_ignored)
+    server.openai = types.SimpleNamespace(
+        chat=types.SimpleNamespace(completions=types.SimpleNamespace(create=create))
+    )
+    return server
+
+
+async def test_n1_makes_single_request_when_n_ignored():
+    create = _CountingCreate()
+    server = _fake_server(create)
+    result = await OpenAIServer._chat_completion_wrapper(
+        server, model="m", messages=[{"role": "user", "content": "hi"}], n=1
+    )
+    assert create.calls == 1
+    assert len(result.choices) == 1
+
+
+async def test_n_gt_1_fans_out_and_merges_choices_when_n_ignored():
+    create = _CountingCreate()
+    server = _fake_server(create)
+    result = await OpenAIServer._chat_completion_wrapper(
+        server, model="m", messages=[{"role": "user", "content": "hi"}], n=3
+    )
+    assert create.calls == 3
+    assert len(result.choices) == 3


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
In `OpenAIServer._chat_completion_wrapper` (`atroposlib/envs/server_handling/openai_server.py`), the `n_kwarg_is_ignored` branch already issues the request(s) with `asyncio.gather(*[... for _ in range(n)])` and takes `completion_list[0]`. It then had an extra `else:` for the `n == 1` case that fired a **second**, redundant `chat.completions.create()` and threw the first result away:

```python
completion_list = await asyncio.gather(*[create(**kwargs) for _ in range(n)])
completions = completion_list[0]
if n > 1:
    for c in completion_list[1:]:
        completions.choices.extend(c.choices)
else:
    completions = await self.openai.chat.completions.create(**kwargs)   # duplicate
```

The sibling `_completion_wrapper` has the same structure **without** this `else`, confirming it is unintended.

Once a server is detected as ignoring `n` (auto-set elsewhere in this file, or configured), **every** `n=1` chat call doubled its request count, latency, token/billing cost and effective inflight load — undermining the load-balancing this layer exists to do.

**Fix:** remove the `else` branch; `completion_list[0]` already holds the single completion.

**Reproduction (before this PR):** with `n_kwarg_is_ignored=True` and `n=1`, `_chat_completion_wrapper` calls `create()` twice. Added `atroposlib/tests/test_openai_server.py` asserting exactly 1 call for `n=1` (fails on the previous code) and correct fan-out/merge for `n>1`.

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)