### PR TITLE
fix: remove double retry on chat_completion (9 attempts instead of 3)

### DIFF
--- a/atroposlib/envs/server_handling/server_baseline.py
+++ b/atroposlib/envs/server_handling/server_baseline.py
@@ -464,9 +464,6 @@ class APIServer(ABC):
             stat_dict["end"] = time.time()
             return completions
 
-    @retry(
-        stop=stop_after_attempt(3), wait=wait_random_exponential(multiplier=1, max=10)
-    )
     async def chat_completion(self, **kwargs) -> ChatCompletion:
         """
         Chat completion handler, waits for the server to be healthy and then calls the chat completion wrapper.

--- a/atroposlib/tests/test_server_baseline_retry.py
+++ b/atroposlib/tests/test_server_baseline_retry.py
@@ -1,0 +1,51 @@
+"""Tests that chat_completion uses a single (3-attempt) retry budget."""
+
+import asyncio
+
+import pytest
+from tenacity import RetryError
+
+from atroposlib.envs.server_handling.server_baseline import (
+    APIServer,
+    APIServerConfig,
+)
+
+
+class _CountingServer(APIServer):
+    def __init__(self, config):
+        super().__init__(config)
+        self.chat_wrapper_calls = 0
+
+    async def _chat_completion_wrapper(self, **kwargs):
+        self.chat_wrapper_calls += 1
+        raise RuntimeError("boom")
+
+    async def _completion_wrapper(self, **kwargs):
+        raise RuntimeError("boom")
+
+    async def _tokens_and_logprobs_completion_wrapper(self, **kwargs):
+        raise RuntimeError("boom")
+
+    async def check_server_status_task(self, *args, **kwargs):
+        return
+
+
+async def test_chat_completion_retries_three_times(monkeypatch):
+    # Make tenacity's backoff instant so the test is fast/deterministic.
+    async def _instant(*args, **kwargs):
+        return
+
+    monkeypatch.setattr(asyncio, "sleep", _instant)
+
+    config = APIServerConfig(
+        model_name="m", base_url=None, api_key="x", health_check=False
+    )
+    server = _CountingServer(config)
+    server.server_healthy = True
+    server.initialized = True
+
+    with pytest.raises(RetryError):
+        await server.chat_completion(messages=[{"role": "user", "content": "hi"}])
+
+    # A single 3-attempt retry budget -- not the nested 3 x 3 = 9.
+    assert server.chat_wrapper_calls == 3


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
`APIServer.chat_completion` (`atroposlib/envs/server_handling/server_baseline.py`) was decorated with `@retry(stop_after_attempt(3))` **and** delegates to `_chat_comp` / `_chat_eval`, which are **each already** decorated with `@retry(stop_after_attempt(3))`. The nesting means a persistently failing call makes up to **3 × 3 = 9** backend calls.

The three sibling public entry points — `completion`, `tokens_and_logprobs_completion`, `get_logprobs` — have **no** outer decorator and delegate to inner-retried helpers, so they cap at 3. The asymmetry shows the outer `@retry` on `chat_completion` is unintended.

On a failing/overloaded chat backend this hammered it at 3× the intended retry budget (and re-ran reasoning-kwargs injection / re-acquired the semaphore each outer attempt) — exactly when the server was least healthy.

**Fix:** remove the outer decorator; the inner `_chat_comp` / `_chat_eval` retries already provide the 3-attempt budget, matching the sibling methods.

**Reproduction (before this PR):** a `chat_completion` whose wrapper always raises calls the backend **9** times. Added `atroposlib/tests/test_server_baseline_retry.py` asserting exactly 3 attempts (fails on the previous code); it patches the tenacity backoff so it runs instantly.

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)