### PR TITLE
fix: count other envs' queued data in /status-env when group size is 1

### DIFF
--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -546,10 +546,12 @@ async def get_status_env(env: EnvIdentifier):
                 sequences_by_env[env_id] = 0
             sequences_by_env[env_id] += seq_count
 
-    # Calculate packed groups for each environment (excluding the requesting env)
-    if max_group_size > 1:
-        for env_id, seq_count in sequences_by_env.items():
-            packed_groups_by_env[env_id] = math.ceil(seq_count / max_group_size)
+    # Calculate packed groups for each environment (excluding the requesting
+    # env). ceil(n / 1) == n, so this holds at max_group_size == 1 too; gating
+    # it on > 1 dropped every other environment's availability from the count
+    # whenever the largest queued group had size 1 (a valid group_size==1 run).
+    for env_id, seq_count in sequences_by_env.items():
+        packed_groups_by_env[env_id] = math.ceil(seq_count / max_group_size)
 
     # Calculate adjusted queue size
     # (curr_env_total_sequences + sum of available sequences from other envs after their minimums)

--- a/atroposlib/tests/test_status_env_queue_size.py
+++ b/atroposlib/tests/test_status_env_queue_size.py
@@ -1,0 +1,37 @@
+"""Tests /status-env queue accounting when the max group size is 1."""
+
+from atroposlib.api import server as api_server
+from atroposlib.api.server import EnvIdentifier, get_status_env
+
+
+def _seq():
+    return [1, 2, 3]  # a single sequence (list of token ids)
+
+
+def _env(registered_id):
+    return {
+        "max_context_len": 100,
+        "weight": 1.0,
+        "connected": True,
+        "group_size": 1,
+        "registered_id": registered_id,
+        "min_batch_allocation": None,
+    }
+
+
+async def test_status_env_counts_other_envs_when_group_size_one():
+    state = api_server.app.state
+    state.envs = [_env(0), _env(1)]
+    # 1 sequence for the requesting env (id 0) and 5 for the other (id 1);
+    # every queued group has size 1 so max_group_size stays 1.
+    state.queue = [{"env_id": 0, "tokens": [_seq()]}] + [
+        {"env_id": 1, "tokens": [_seq()]} for _ in range(5)
+    ]
+    state.batchsize = 8
+    state.status_dict = {"step": 0}
+
+    result = await get_status_env(EnvIdentifier(env_id=0))
+
+    assert result["max_group_size"] == 1
+    # 1 (own) + 5 (other env), group_size 1 -> 6, not just the 1 own sequence.
+    assert result["queue_size"] == 6


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description
`/status-env` (`atroposlib/api/server.py`) reports `queue_size`, the availability/backpressure signal environments poll. It builds `packed_groups_by_env` (the per-env sequence accounting for every environment **other** than the requester) only inside `if max_group_size > 1:`.

`max_group_size` starts at `1` and only rises above 1 if some queued group holds ≥2 sequences. So for a perfectly valid `group_size == 1` run, the block never executes: `packed_groups_by_env` stays empty, `available_from_others` stays `0`, and `queue_size` collapses to **only the requesting env's own sequences** — silently excluding all other environments' available data.

**Reproduction (before this PR):** queue with 1 sequence from the requesting env and 5 from another env, every group of size 1 → reported `queue_size == 1` instead of `6`. The moment any group has size ≥2 (so `max_group_size > 1`), the same data reports correctly, confirming the gate is the only cause.

**Fix:** remove the `if max_group_size > 1:` gate. `math.ceil(n / 1) == n`, so the packing math is already correct at size 1.

Added `atroposlib/tests/test_status_env_queue_size.py` (fails on the previous code).

### Related Issues
N/A

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation — N/A (behavior-only bug fix, no docs affected)
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — N/A (no new public API; only test functions added)
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A (no new env vars)