### PR TITLE
fix: correct over-escaped regexes in instruction-following reward validators

### DIFF
--- a/atroposlib/tests/test_if_validators.py
+++ b/atroposlib/tests/test_if_validators.py
@@ -1,0 +1,59 @@
+r"""Regression tests for the instruction-following reward validators.
+
+Several validators in ``instruction_following_algorithm_environment`` were
+ported from allenai/open-instruct with an extra layer of backslash escaping,
+e.g. ``re.findall(r"\\[(.*?)\\]", text)`` — as the regex engine sees it that
+is ``\\[`` (a literal backslash followed by a character class), not ``\[`` (a
+literal bracket). Those patterns therefore never matched normal model output,
+so the affected validators silently returned 0 / False and zeroed out the RL
+reward for any rollout whose ground-truth constraint used them.
+
+These tests pin the intended behavior: a response that satisfies the
+constraint must score as satisfying it.
+"""
+
+import pytest
+
+# The environment module pulls in the training stack; skip cleanly where those
+# optional deps aren't installed rather than erroring at collection time.
+pytest.importorskip("datasets")
+pytest.importorskip("wandb")
+pytest.importorskip("langdetect")
+
+from environments.instruction_following_algorithm_environment import (  # noqa: E402
+    validate_frequency_capital_words,
+    validate_placeholders,
+    validate_sections,
+    verify_bullet_points,
+    verify_keyword_frequency,
+)
+
+
+def test_validate_placeholders_matches_bracketed_spans():
+    ok, found = validate_placeholders("Ship to [address] and [name].", 2)
+    assert ok is True
+    assert found == ["address", "name"]
+
+
+def test_verify_bullet_points_counts_markdown_bullets():
+    assert verify_bullet_points("* one\n* two\n* three", 3) is True
+    assert verify_bullet_points("- a\n+ b", 2) is True
+
+
+def test_validate_sections_counts_splitter_occurrences():
+    assert validate_sections("SECTION 1: alpha SECTION 2: beta", 2, "SECTION") is True
+
+
+def test_verify_keyword_frequency_extracts_words():
+    # _extract_words must find real word tokens for the count to work.
+    assert verify_keyword_frequency("cat cat dog", "cat", 2) is True
+    assert verify_keyword_frequency("cat cat dog", "cat", 1) is False
+
+
+def test_validate_frequency_capital_words_finds_all_caps():
+    assert (
+        validate_frequency_capital_words("USA and NASA are here", 2, "at least") is True
+    )
+    assert (
+        validate_frequency_capital_words("nothing shouted here", 1, "at least") is False
+    )

--- a/environments/instruction_following_algorithm_environment.py
+++ b/environments/instruction_following_algorithm_environment.py
@@ -1372,7 +1372,7 @@ class InstructionFollowingEnv(BaseEnv):
 
 # Helper function for verify_keyword_frequency, moved import re to top level
 def _extract_words(text: str) -> List[str]:
-    return re.findall(r"\\b\\w+\\b", text.lower())
+    return re.findall(r"\b\w+\b", text.lower())
 
 
 # include keywords: Include keywords {keyword1}, {keyword2} in your response
@@ -1526,7 +1526,7 @@ def verify_postscript(text: str, postscript_marker: str) -> bool:
 
 # Number Placeholder: The response must contain at least {N} placeholders ... [address].
 def validate_placeholders(text: str, N: int) -> Tuple[bool, List[str]]:
-    placeholders_found = re.findall(r"\\[(.*?)\\]", text)  # Matches [content]
+    placeholders_found = re.findall(r"\[(.*?)\]", text)  # Matches [content]
     return len(placeholders_found) >= N, placeholders_found
 
 
@@ -1537,9 +1537,7 @@ def verify_bullet_points(
     lines = text.splitlines()
     # Markdown bullets usually start with '*', '-', or '+' followed by a space.
     bullet_points = [
-        line.strip()
-        for line in lines
-        if re.match(r"^(\\s*)[\\*\\-\\+]\\s+", line.strip())
+        line.strip() for line in lines if re.match(r"^(\s*)[\*\-\+]\s+", line.strip())
     ]
     return len(bullet_points) == N
 
@@ -1594,9 +1592,7 @@ def validate_sections(text: str, N: int, section_splitter: str) -> bool:
     # This might need to be adjusted based on IFEval's exact expectation for "X".
     # For "SECTION 1.", "SECTION 2.", if splitter is "SECTION ":
     actual_sections = len(
-        re.findall(
-            re.escape(section_splitter) + r"\\s*\\d*[:\\.\\s]", text, re.IGNORECASE
-        )
+        re.findall(re.escape(section_splitter) + r"\s*\d*[:\.\s]", text, re.IGNORECASE)
     )
 
     # If N=0 and no splitters, it's true. If N>0 and no splitters, false.
@@ -1654,7 +1650,7 @@ def validate_lowercase(text: str) -> bool:
 # Frequency of All-capital Words
 def validate_frequency_capital_words(text: str, N: int, quantifier: str) -> bool:
     # Words with all capital letters, e.g., "NASA", "AI". Min 2 chars to be a "word".
-    capital_words = re.findall(r"\\b[A-Z]{2,}\\b", text)
+    capital_words = re.findall(r"\b[A-Z]{2,}\b", text)
     actual_count = len(capital_words)
     tolerance = max(round(N * 0.1), 1)  # For 'around'
 


### PR DESCRIPTION
## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## 📝 General Information
### Description

Five instruction-following reward validators in `environments/instruction_following_algorithm_environment.py` (ported "from allenai/open-instruct if_functions.py", per the comment at the top of that section) carry an extra layer of backslash escaping in their raw-string patterns. Because they are `r"..."` strings, the doubled backslash is literal: the regex engine reads `r"\\["` as **a literal backslash followed by a character class**, not `r"\["` (a literal `[`). So these patterns only match text that actually contains backslash characters, and never match normal model output.

Each of these functions is a reward verifier looked up in `IF_FUNCTIONS_MAP` and called via `score()` — its boolean/count result *is* the reward. So a rollout that perfectly satisfies the instruction still scores 0 (or `True` only in the degenerate `N == 0` case), silently poisoning the RL signal for every constraint type that uses one of them:

| Line | Function | Pattern (as the engine sees it) | Effect on normal output |
|------|----------|--------------------------------|-------------------------|
| 1375 | `_extract_words` → `verify_keyword_frequency` | `\\b\\w+\\b` | returns `[]` → keyword-frequency count always 0 |
| 1529 | `validate_placeholders` | `\\[(.*?)\\]` | never finds `[address]` → `(False, [])` |
| 1542 | `verify_bullet_points` | `^(\\s*)[\\*\\-\\+]\\s+` | never matches `* item` → 0 bullets |
| 1598 | `validate_sections` | `SECTION\\s*\\d*[:\\.\\s]` | never matches `SECTION 1:` → 0 sections |
| 1657 | `validate_frequency_capital_words` | `\\b[A-Z]{2,}\\b` | never matches `USA` → 0 all-caps words |

Proof (patterns run exactly as written in `main`):

```
_extract_words('hello world')              -> []            (want ['hello','world'])
validate_placeholders('[a] [b]', 2)        -> (False, [])   (want (True, ['a','b']))
verify_bullet_points('* x\n* y', 2)        -> False         (want True)
validate_sections('SECTION 1: SECTION 2:', 2, 'SECTION') -> 0  (want 2)
validate_frequency_capital_words('USA NASA', ...) -> []     (want ['USA','NASA'])
```

The fix collapses the doubled backslashes to single. `validate_highlighted_sections`'s `r"\*(.*?)(?<!\\)\*"` is **intentionally** escaped (the `(?<!\\)` is a lookbehind for a literal backslash) and is left unchanged. The upstream open-instruct source uses single backslashes, so the intended behavior is unambiguous.

### Related Issues

No existing issue — found via source audit. Opening this as the fix.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## ✅ Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas (kept the existing `# Matches [content]` comment; the fix is self-evident)
- [ ] I have made corresponding changes to the documentation — N/A
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Docstrings added for all new public classes / functions — added a module docstring to the new test file explaining the escaping bug
- [x] If .env vars required, did you add it to the .env.example in repo root? — N/A

### How to test
```
pytest atroposlib/tests/test_if_validators.py
```
5 pass on this branch. Revert only the env file and rerun — all 5 fail (the validators go silent), which is the exact reward-zeroing behavior on `main`.
