### PR TITLE
feat(community): add chiral weight symmetry RL environment

### DIFF
--- a/environments/community/chiral_weight_symmetry/README.md
+++ b/environments/community/chiral_weight_symmetry/README.md
@@ -1,0 +1,3 @@
+# Chiral Weight Symmetry
+
+Neural networks with left/right-handed chiral weight configurations.

--- a/environments/community/chiral_weight_symmetry/chiral_weight_symmetry_env.py
+++ b/environments/community/chiral_weight_symmetry/chiral_weight_symmetry_env.py
@@ -1,30 +1,56 @@
 from typing import List, Optional
+
 from pydantic import Field
+
 from atroposlib.envs.base import BaseEnv, BaseEnvConfig, ScoredDataGroup
 from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
 
+
 class ChiralWeightConfig(BaseEnvConfig):
-    system_prompt: Optional[str] = Field("You simulate chiral weight symmetry. Respond with combined output.", description="System prompt")
+    system_prompt: Optional[str] = Field(
+        "You simulate chiral weight symmetry. Respond with combined output.",
+        description="System prompt",
+    )
+
 
 class ChiralWeightEnv(BaseEnv):
     env_config_cls = ChiralWeightConfig
+
     async def get_next_item(self):
         prompt = "Compute combined chiral output for input [1, 2, 3] via left and right weight branches."
-        return (tuple([frozenset({"role": "user", "content": prompt}.items())]), None, None)
+        return (
+            tuple([frozenset({"role": "user", "content": prompt}.items())]),
+            None,
+            None,
+        )
+
     async def collect_trajectories(self, item):
         user_content = dict(item[0][0])["content"]
         messages = [{"role": "user", "content": user_content}]
         prompt = self.tokenizer.apply_chat_template(messages, tokenize=False)
-        completions = await self.server.completion(prompt=prompt, n=self.config.group_size)
+        completions = await self.server.completion(
+            prompt=prompt, n=self.config.group_size
+        )
         trajectories = []
         for c in completions.choices:
             text = c.text if hasattr(c, "text") else c.message.content
-            trajectories.append([{"role": "user", "content": user_content}, {"role": "assistant", "content": text}])
+            trajectories.append(
+                [
+                    {"role": "user", "content": user_content},
+                    {"role": "assistant", "content": text},
+                ]
+            )
         return trajectories, []
+
     async def score(self, rollout_group_data: List) -> Optional[ScoredDataGroup]:
-        scored = ScoredDataGroup(); scored["tokens"] = []; scored["masks"] = []; scored["scores"] = []
+        scored = ScoredDataGroup()
+        scored["tokens"] = []
+        scored["masks"] = []
+        scored["scores"] = []
         for traj in rollout_group_data:
             reward = 1.0 if any(c.isdigit() for c in traj[-1]["content"]) else 0.0
             out = tokenize_for_trainer(self.tokenizer, traj)
-            scored["tokens"].append(out["tokens"]); scored["masks"].append(out["masks"]); scored["scores"].append(reward)
+            scored["tokens"].append(out["tokens"])
+            scored["masks"].append(out["masks"])
+            scored["scores"].append(reward)
         return scored

--- a/environments/community/chiral_weight_symmetry/chiral_weight_symmetry_env.py
+++ b/environments/community/chiral_weight_symmetry/chiral_weight_symmetry_env.py
@@ -1,0 +1,30 @@
+from typing import List, Optional
+from pydantic import Field
+from atroposlib.envs.base import BaseEnv, BaseEnvConfig, ScoredDataGroup
+from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
+
+class ChiralWeightConfig(BaseEnvConfig):
+    system_prompt: Optional[str] = Field("You simulate chiral weight symmetry. Respond with combined output.", description="System prompt")
+
+class ChiralWeightEnv(BaseEnv):
+    env_config_cls = ChiralWeightConfig
+    async def get_next_item(self):
+        prompt = "Compute combined chiral output for input [1, 2, 3] via left and right weight branches."
+        return (tuple([frozenset({"role": "user", "content": prompt}.items())]), None, None)
+    async def collect_trajectories(self, item):
+        user_content = dict(item[0][0])["content"]
+        messages = [{"role": "user", "content": user_content}]
+        prompt = self.tokenizer.apply_chat_template(messages, tokenize=False)
+        completions = await self.server.completion(prompt=prompt, n=self.config.group_size)
+        trajectories = []
+        for c in completions.choices:
+            text = c.text if hasattr(c, "text") else c.message.content
+            trajectories.append([{"role": "user", "content": user_content}, {"role": "assistant", "content": text}])
+        return trajectories, []
+    async def score(self, rollout_group_data: List) -> Optional[ScoredDataGroup]:
+        scored = ScoredDataGroup(); scored["tokens"] = []; scored["masks"] = []; scored["scores"] = []
+        for traj in rollout_group_data:
+            reward = 1.0 if any(c.isdigit() for c in traj[-1]["content"]) else 0.0
+            out = tokenize_for_trainer(self.tokenizer, traj)
+            scored["tokens"].append(out["tokens"]); scored["masks"].append(out["masks"]); scored["scores"].append(reward)
+        return scored


### PR DESCRIPTION
Adds `environments/community/chiral_weight_symmetry` — **Neural networks with left/right-handed chiral weight configurations.**

Inherits from `BaseEnv` following community contribution guidelines.