### PR TITLE
feat(community): add topological data homology nets RL environment

### DIFF
--- a/environments/community/topological_data_homology_nets/README.md
+++ b/environments/community/topological_data_homology_nets/README.md
@@ -1,0 +1,3 @@
+# Topological Data Homology Nets
+
+Computing persistence homology diagrams on network activations dynamically.

--- a/environments/community/topological_data_homology_nets/topological_data_homology_nets_env.py
+++ b/environments/community/topological_data_homology_nets/topological_data_homology_nets_env.py
@@ -1,31 +1,60 @@
 from typing import List, Optional
+
 from pydantic import Field
+
 from atroposlib.envs.base import BaseEnv, BaseEnvConfig, ScoredDataGroup
 from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
 
+
 class TopologicalHomologyConfig(BaseEnvConfig):
-    system_prompt: Optional[str] = Field("You estimate topological Betti numbers of point clouds. Return integer.", description="System prompt")
+    system_prompt: Optional[str] = Field(
+        "You estimate topological Betti numbers of point clouds. Return integer.",
+        description="System prompt",
+    )
+
 
 class TopologicalHomologyEnv(BaseEnv):
     env_config_cls = TopologicalHomologyConfig
+
     async def get_next_item(self):
         prompt = "Estimate Betti number b0 for cluster of points: (0,0), (0.1,0.2), (5.0,5.0)."
-        return (tuple([frozenset({"role": "user", "content": prompt}.items())]), None, None)
+        return (
+            tuple([frozenset({"role": "user", "content": prompt}.items())]),
+            None,
+            None,
+        )
+
     async def collect_trajectories(self, item):
         user_content = dict(item[0][0])["content"]
         messages = [{"role": "user", "content": user_content}]
         prompt = self.tokenizer.apply_chat_template(messages, tokenize=False)
-        completions = await self.server.completion(prompt=prompt, n=self.config.group_size)
+        completions = await self.server.completion(
+            prompt=prompt, n=self.config.group_size
+        )
         trajectories = []
         for c in completions.choices:
             text = c.text if hasattr(c, "text") else c.message.content
-            trajectories.append([{"role": "user", "content": user_content}, {"role": "assistant", "content": text}])
+            trajectories.append(
+                [
+                    {"role": "user", "content": user_content},
+                    {"role": "assistant", "content": text},
+                ]
+            )
         return trajectories, []
+
     async def score(self, rollout_group_data: List) -> Optional[ScoredDataGroup]:
-        scored = ScoredDataGroup(); scored["tokens"] = []; scored["masks"] = []; scored["scores"] = []
+        scored = ScoredDataGroup()
+        scored["tokens"] = []
+        scored["masks"] = []
+        scored["scores"] = []
         for traj in rollout_group_data:
-            try: val = int(traj[-1]["content"].strip()); reward = 1.0 if val == 2 else 0.2
-            except: reward = 0.0
+            try:
+                val = int(traj[-1]["content"].strip())
+                reward = 1.0 if val == 2 else 0.2
+            except:
+                reward = 0.0
             out = tokenize_for_trainer(self.tokenizer, traj)
-            scored["tokens"].append(out["tokens"]); scored["masks"].append(out["masks"]); scored["scores"].append(reward)
+            scored["tokens"].append(out["tokens"])
+            scored["masks"].append(out["masks"])
+            scored["scores"].append(reward)
         return scored

--- a/environments/community/topological_data_homology_nets/topological_data_homology_nets_env.py
+++ b/environments/community/topological_data_homology_nets/topological_data_homology_nets_env.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+from pydantic import Field
+from atroposlib.envs.base import BaseEnv, BaseEnvConfig, ScoredDataGroup
+from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
+
+class TopologicalHomologyConfig(BaseEnvConfig):
+    system_prompt: Optional[str] = Field("You estimate topological Betti numbers of point clouds. Return integer.", description="System prompt")
+
+class TopologicalHomologyEnv(BaseEnv):
+    env_config_cls = TopologicalHomologyConfig
+    async def get_next_item(self):
+        prompt = "Estimate Betti number b0 for cluster of points: (0,0), (0.1,0.2), (5.0,5.0)."
+        return (tuple([frozenset({"role": "user", "content": prompt}.items())]), None, None)
+    async def collect_trajectories(self, item):
+        user_content = dict(item[0][0])["content"]
+        messages = [{"role": "user", "content": user_content}]
+        prompt = self.tokenizer.apply_chat_template(messages, tokenize=False)
+        completions = await self.server.completion(prompt=prompt, n=self.config.group_size)
+        trajectories = []
+        for c in completions.choices:
+            text = c.text if hasattr(c, "text") else c.message.content
+            trajectories.append([{"role": "user", "content": user_content}, {"role": "assistant", "content": text}])
+        return trajectories, []
+    async def score(self, rollout_group_data: List) -> Optional[ScoredDataGroup]:
+        scored = ScoredDataGroup(); scored["tokens"] = []; scored["masks"] = []; scored["scores"] = []
+        for traj in rollout_group_data:
+            try: val = int(traj[-1]["content"].strip()); reward = 1.0 if val == 2 else 0.2
+            except: reward = 0.0
+            out = tokenize_for_trainer(self.tokenizer, traj)
+            scored["tokens"].append(out["tokens"]); scored["masks"].append(out["masks"]); scored["scores"].append(reward)
+        return scored


### PR DESCRIPTION
Adds `environments/community/topological_data_homology_nets` — **Computing persistence homology diagrams on network activations dynamically.**

Inherits from `BaseEnv` following community contribution guidelines.