### PR TITLE
feat(community): add mitochondrial energy backprop RL environment

### DIFF
--- a/environments/community/mitochondrial_energy_backprop/README.md
+++ b/environments/community/mitochondrial_energy_backprop/README.md
@@ -1,0 +1,3 @@
+# Mitochondrial Energy Backprop
+
+Training loops constrained by simulated metabolic ATP energy limits.

--- a/environments/community/mitochondrial_energy_backprop/mitochondrial_energy_backprop_env.py
+++ b/environments/community/mitochondrial_energy_backprop/mitochondrial_energy_backprop_env.py
@@ -1,31 +1,60 @@
 from typing import List, Optional
+
 from pydantic import Field
+
 from atroposlib.envs.base import BaseEnv, BaseEnvConfig, ScoredDataGroup
 from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
 
+
 class MitochondrialBackpropConfig(BaseEnvConfig):
-    system_prompt: Optional[str] = Field("You simulate metabolic neural computation. Return remaining ATP.", description="System prompt")
+    system_prompt: Optional[str] = Field(
+        "You simulate metabolic neural computation. Return remaining ATP.",
+        description="System prompt",
+    )
+
 
 class MitochondrialBackpropEnv(BaseEnv):
     env_config_cls = MitochondrialBackpropConfig
+
     async def get_next_item(self):
         prompt = "Compute remaining ATP after forward pass with input x=50.0 and initial ATP=100.0."
-        return (tuple([frozenset({"role": "user", "content": prompt}.items())]), None, None)
+        return (
+            tuple([frozenset({"role": "user", "content": prompt}.items())]),
+            None,
+            None,
+        )
+
     async def collect_trajectories(self, item):
         user_content = dict(item[0][0])["content"]
         messages = [{"role": "user", "content": user_content}]
         prompt = self.tokenizer.apply_chat_template(messages, tokenize=False)
-        completions = await self.server.completion(prompt=prompt, n=self.config.group_size)
+        completions = await self.server.completion(
+            prompt=prompt, n=self.config.group_size
+        )
         trajectories = []
         for c in completions.choices:
             text = c.text if hasattr(c, "text") else c.message.content
-            trajectories.append([{"role": "user", "content": user_content}, {"role": "assistant", "content": text}])
+            trajectories.append(
+                [
+                    {"role": "user", "content": user_content},
+                    {"role": "assistant", "content": text},
+                ]
+            )
         return trajectories, []
+
     async def score(self, rollout_group_data: List) -> Optional[ScoredDataGroup]:
-        scored = ScoredDataGroup(); scored["tokens"] = []; scored["masks"] = []; scored["scores"] = []
+        scored = ScoredDataGroup()
+        scored["tokens"] = []
+        scored["masks"] = []
+        scored["scores"] = []
         for traj in rollout_group_data:
-            try: val = float(traj[-1]["content"].strip()); reward = 1.0 - abs(val - 95.0) / 100.0
-            except: reward = 0.0
+            try:
+                val = float(traj[-1]["content"].strip())
+                reward = 1.0 - abs(val - 95.0) / 100.0
+            except:
+                reward = 0.0
             out = tokenize_for_trainer(self.tokenizer, traj)
-            scored["tokens"].append(out["tokens"]); scored["masks"].append(out["masks"]); scored["scores"].append(reward)
+            scored["tokens"].append(out["tokens"])
+            scored["masks"].append(out["masks"])
+            scored["scores"].append(reward)
         return scored

--- a/environments/community/mitochondrial_energy_backprop/mitochondrial_energy_backprop_env.py
+++ b/environments/community/mitochondrial_energy_backprop/mitochondrial_energy_backprop_env.py
@@ -1,0 +1,31 @@
+from typing import List, Optional
+from pydantic import Field
+from atroposlib.envs.base import BaseEnv, BaseEnvConfig, ScoredDataGroup
+from atroposlib.utils.tokenize_for_trainer import tokenize_for_trainer
+
+class MitochondrialBackpropConfig(BaseEnvConfig):
+    system_prompt: Optional[str] = Field("You simulate metabolic neural computation. Return remaining ATP.", description="System prompt")
+
+class MitochondrialBackpropEnv(BaseEnv):
+    env_config_cls = MitochondrialBackpropConfig
+    async def get_next_item(self):
+        prompt = "Compute remaining ATP after forward pass with input x=50.0 and initial ATP=100.0."
+        return (tuple([frozenset({"role": "user", "content": prompt}.items())]), None, None)
+    async def collect_trajectories(self, item):
+        user_content = dict(item[0][0])["content"]
+        messages = [{"role": "user", "content": user_content}]
+        prompt = self.tokenizer.apply_chat_template(messages, tokenize=False)
+        completions = await self.server.completion(prompt=prompt, n=self.config.group_size)
+        trajectories = []
+        for c in completions.choices:
+            text = c.text if hasattr(c, "text") else c.message.content
+            trajectories.append([{"role": "user", "content": user_content}, {"role": "assistant", "content": text}])
+        return trajectories, []
+    async def score(self, rollout_group_data: List) -> Optional[ScoredDataGroup]:
+        scored = ScoredDataGroup(); scored["tokens"] = []; scored["masks"] = []; scored["scores"] = []
+        for traj in rollout_group_data:
+            try: val = float(traj[-1]["content"].strip()); reward = 1.0 - abs(val - 95.0) / 100.0
+            except: reward = 0.0
+            out = tokenize_for_trainer(self.tokenizer, traj)
+            scored["tokens"].append(out["tokens"]); scored["masks"].append(out["masks"]); scored["scores"].append(reward)
+        return scored


### PR DESCRIPTION
Adds `environments/community/mitochondrial_energy_backprop` — **Training loops constrained by simulated metabolic ATP energy limits.**

Inherits from `BaseEnv` following community contribution guidelines.