### PR TITLE
fix: preserve apostrophes in tool call arguments (#478)

### DIFF
--- a/atroposlib/tests/test_tool_call_parser.py
+++ b/atroposlib/tests/test_tool_call_parser.py
@@ -1,5 +1,6 @@
 from atroposlib.utils.tool_call_parser import parse_tool_call
 
+
 def test_parse_tool_call_with_apostrophe_in_argument():
     tools = [{"name": "web_search"}]
     resp = '<tool_call>{"name": "web_search", "arguments": {"query": "what\'s the weather"}}</tool_call>'
@@ -7,6 +8,7 @@ def test_parse_tool_call_with_apostrophe_in_argument():
     assert is_error is False
     assert name == "web_search"
     assert args["query"] == "what's the weather"
+
 
 def test_parse_tool_call_single_quoted_dict_still_works():
     tools = [{"name": "web_search"}]

--- a/atroposlib/tests/test_tool_call_parser.py
+++ b/atroposlib/tests/test_tool_call_parser.py
@@ -1,0 +1,17 @@
+from atroposlib.utils.tool_call_parser import parse_tool_call
+
+def test_parse_tool_call_with_apostrophe_in_argument():
+    tools = [{"name": "web_search"}]
+    resp = '<tool_call>{"name": "web_search", "arguments": {"query": "what\'s the weather"}}</tool_call>'
+    name, args, is_error = parse_tool_call(resp, available_tools=tools)
+    assert is_error is False
+    assert name == "web_search"
+    assert args["query"] == "what's the weather"
+
+def test_parse_tool_call_single_quoted_dict_still_works():
+    tools = [{"name": "web_search"}]
+    resp = "<tool_call>{'name': 'web_search', 'arguments': {'query': 'weather today'}}</tool_call>"
+    name, args, is_error = parse_tool_call(resp, available_tools=tools)
+    assert is_error is False
+    assert name == "web_search"
+    assert args["query"] == "weather today"

--- a/atroposlib/utils/tool_call_parser.py
+++ b/atroposlib/utils/tool_call_parser.py
@@ -63,6 +63,7 @@ def parse_tool_call(
             # Fallback: Python-literal dict (e.g. single-quoted), without
             # mangling apostrophes inside string values.
             import ast
+
             tool_call = ast.literal_eval(tool_call_content)
 
         # Extract tool name and arguments

--- a/atroposlib/utils/tool_call_parser.py
+++ b/atroposlib/utils/tool_call_parser.py
@@ -56,10 +56,14 @@ def parse_tool_call(
 
     # Parse JSON
     try:
-        # Handle potential single quotes
-        tool_call_content = tool_call_content.replace("'", '"')
-
-        tool_call = json.loads(tool_call_content, strict=False)
+        try:
+            # Preferred path: valid JSON, apostrophes untouched.
+            tool_call = json.loads(tool_call_content, strict=False)
+        except json.JSONDecodeError:
+            # Fallback: Python-literal dict (e.g. single-quoted), without
+            # mangling apostrophes inside string values.
+            import ast
+            tool_call = ast.literal_eval(tool_call_content)
 
         # Extract tool name and arguments
         tool_name = tool_call.get("name", "")
@@ -81,6 +85,6 @@ def parse_tool_call(
         logger.warning(f"Parsed tool call: {tool_name}, {arguments}")
         return tool_name, arguments, False
 
-    except (json.JSONDecodeError, Exception) as json_error:
-        logger.error(f"Failed to parse tool call: {json_error}", exc_info=True)
+    except (json.JSONDecodeError, ValueError, SyntaxError, Exception) as parse_error:
+        logger.error(f"Failed to parse tool call: {parse_error}", exc_info=True)
         return "-ERROR-", {}, True


### PR DESCRIPTION
This PR resolves issue #478 by parsing valid JSON tool calls directly rather than blindly replacing all single quotes with double quotes. This preserves apostrophes in arguments, with a fallback to `ast.literal_eval` for Python dict literals.

Closes #478.