### PR TITLE
fix: accept GET /status-env via query param, deprecate JSON body (#449)

### DIFF
--- a/atroposlib/api/server.py
+++ b/atroposlib/api/server.py
@@ -4,7 +4,7 @@ import time
 import uuid
 from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, status
+from fastapi import FastAPI, HTTPException, Query, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import PlainTextResponse
@@ -469,7 +469,25 @@ async def get_status():
 
 
 @app.get("/status-env")
-async def get_status_env(env: EnvIdentifier):
+async def get_status_env(
+    env_id: Optional[int] = Query(default=None),
+    env: Optional[EnvIdentifier] = None,
+):
+    if env_id is None:
+        if env is not None:
+            logger.warning(
+                "GET /status-env: passing env_id via JSON body is deprecated and "
+                "non-standard per RFC 9110 (GET requests SHOULD NOT carry content). "
+                "Pass it as a query parameter instead: GET /status-env?env_id=<id>. "
+                "Body support will be removed in a future release."
+            )
+            env_id = env.env_id
+        else:
+            raise HTTPException(
+                status_code=422,
+                detail="env_id is required, e.g. GET /status-env?env_id=<id>",
+            )
+
     total = sum(
         [
             x["max_context_len"] * max(0.0, x["weight"])
@@ -477,10 +495,10 @@ async def get_status_env(env: EnvIdentifier):
             if x["connected"]
         ]
     )
-    env_group_size = app.state.envs[env.env_id]["group_size"]
+    env_group_size = app.state.envs[env_id]["group_size"]
     env_weight = (
-        app.state.envs[env.env_id]["max_context_len"]
-        * app.state.envs[env.env_id]["weight"]
+        app.state.envs[env_id]["max_context_len"]
+        * app.state.envs[env_id]["weight"]
         / total
     )
     env_weight = max(
@@ -507,13 +525,13 @@ async def get_status_env(env: EnvIdentifier):
         group_size = len(item.get("tokens", []))
         if group_size > max_group_size:
             max_group_size = group_size
-        if item.get("env_id") == env.env_id:
+        if item.get("env_id") == env_id:
             # update the group size for the requesting env, handle cases where the group size may be dynamic with max
             env_group_size = max(env_group_size, group_size)
             num_self_sequences_in_queue += group_size
 
     # update the group size for the requesting env
-    app.state.envs[env.env_id]["group_size"] = env_group_size
+    app.state.envs[env_id]["group_size"] = env_group_size
 
     # Calculate minimum sequences allocated to each environment
     batch_size = getattr(app.state, "batchsize", 0)
@@ -523,9 +541,9 @@ async def get_status_env(env: EnvIdentifier):
             env_config.get("connected", False)
             and env_config.get("min_batch_allocation") is not None
         ):
-            env_id = env_config["registered_id"]
+            env_id_config = env_config["registered_id"]
             min_sequences = int(batch_size * env_config["min_batch_allocation"])
-            min_sequences_by_env[env_id] = min_sequences
+            min_sequences_by_env[env_id_config] = min_sequences
 
     # Count sequences and calculate packed groups for each environment
     import math
@@ -535,28 +553,28 @@ async def get_status_env(env: EnvIdentifier):
     curr_env_total_sequences = 0
 
     for item in queue:
-        env_id = item.get("env_id")
+        item_env_id = item.get("env_id")
         seq_count = len(item.get("tokens", []))
 
         # Special handling for the requesting environment
-        if env_id == env.env_id:
+        if item_env_id == env_id:
             curr_env_total_sequences += seq_count
         else:
-            if env_id not in sequences_by_env:
-                sequences_by_env[env_id] = 0
-            sequences_by_env[env_id] += seq_count
+            if item_env_id not in sequences_by_env:
+                sequences_by_env[item_env_id] = 0
+            sequences_by_env[item_env_id] += seq_count
 
     # Calculate packed groups for each environment (excluding the requesting env)
     if max_group_size > 1:
-        for env_id, seq_count in sequences_by_env.items():
-            packed_groups_by_env[env_id] = math.ceil(seq_count / max_group_size)
+        for item_env_id, seq_count in sequences_by_env.items():
+            packed_groups_by_env[item_env_id] = math.ceil(seq_count / max_group_size)
 
     # Calculate adjusted queue size
     # (curr_env_total_sequences + sum of available sequences from other envs after their minimums)
     available_from_others = 0
-    for env_id in packed_groups_by_env:
-        packed_sequences = packed_groups_by_env[env_id] * max_group_size
-        min_sequences = min_sequences_by_env.get(env_id, 0)
+    for item_env_id in packed_groups_by_env:
+        packed_sequences = packed_groups_by_env[item_env_id] * max_group_size
+        min_sequences = min_sequences_by_env.get(item_env_id, 0)
         available_from_others += max(0, packed_sequences - min_sequences)
 
     env_queue_size = curr_env_total_sequences + available_from_others

--- a/atroposlib/envs/base.py
+++ b/atroposlib/envs/base.py
@@ -1015,7 +1015,7 @@ class BaseEnv(ABC):
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 f"{self.config.rollout_server_url}/status-env",
-                json={"env_id": self.env_id},
+                params={"env_id": self.env_id},
             ) as resp:
                 self.status_dict = await parse_http_response(resp, logger)
                 new_weight = self.status_dict["env_weight"]

--- a/atroposlib/tests/test_api_compression.py
+++ b/atroposlib/tests/test_api_compression.py
@@ -256,6 +256,17 @@ class TestAPICompression:
         assert post_response.status_code == 200
 
         status_response = requests.get(
+            "http://localhost:8000/status-env", params={"env_id": env_id}
+        )
+        assert status_response.status_code == 200
+        status_data = status_response.json()
+        assert "queue_size" in status_data
+
+    def test_status_env_legacy_json_body_still_works(self, api_server):
+        """GET /status-env still accepts env_id in JSON body (deprecated path, Closes #449)."""
+        env_id = api_server
+        # Legacy call: JSON body instead of query param — should still return 200
+        status_response = requests.get(
             "http://localhost:8000/status-env", json={"env_id": env_id}
         )
         assert status_response.status_code == 200


### PR DESCRIPTION
## Summary

Resolves #449 -- GET /status-env required a JSON body, which violates RFC 9110 (GET requests SHOULD NOT carry content).

This is a **non-breaking transition**, deliberately differentiated from the closed PR #471 which took a breaking query-param-only approach.

## What changed

### atroposlib/api/server.py
- Endpoint now accepts env_id as a **query parameter**: GET /status-env?env_id=0
- Legacy JSON body is still accepted, but logs a deprecation warning
- Returns HTTP 422 with a clear message if neither is provided

### atroposlib/envs/base.py
- Updated get_status() to send params instead of json body

### atroposlib/tests/test_api_compression.py
- Updated existing test to use params=
- Added new test test_status_env_legacy_json_body_still_works to confirm the deprecated body path still returns 200 (proving non-breaking)

## Why this approach
The previous attempt (#471) was a clean switch to query params only -- breaking all existing callers. This PR keeps the old JSON body path alive with a deprecation warning, making it safe to merge immediately.

Closes #449