### PR TITLE
fix(base): guard handle_env against a concurrently evicted item uuid

### DIFF
--- a/atroposlib/envs/base.py
+++ b/atroposlib/envs/base.py
@@ -958,10 +958,11 @@ class BaseEnv(ABC):
         """
         Handle the rollout of an item
         """
-        item = self.running_items.get(item_uuid)["item"]
-        if item is None:
+        entry = self.running_items.get(item_uuid)
+        if entry is None:
             logger.warning("item %s not found... returning", item_uuid)
             return None
+        item = entry["item"]
         start_time = time.time()
         logger.debug(f"handle_env: Starting with item: {item}")
         # do a rollout with item

--- a/atroposlib/tests/test_handle_env_missing_item.py
+++ b/atroposlib/tests/test_handle_env_missing_item.py
@@ -1,0 +1,76 @@
+"""Regression tests for BaseEnv.handle_env when an item uuid is missing.
+
+handle_env coroutines are scheduled with asyncio.create_task before they run,
+and self.running_items can be reset or popped by several concurrent code paths
+(the STOP_TRAIN eval branch, the off-policy overflow branch, the worker-reduction
+and worker-timeout paths). A uuid can therefore be evicted before its scheduled
+handle_env first looks it up, so the lookup must tolerate a missing key.
+"""
+
+import asyncio
+
+from atroposlib.envs.base import BaseEnv
+
+
+class _MinimalEnv(BaseEnv):
+    """Concrete BaseEnv with the abstract methods stubbed out.
+
+    Instances are created without running BaseEnv.__init__ so that handle_env can
+    be exercised in isolation without the full config/tokenizer/server setup.
+    """
+
+    async def get_next_item(self):
+        raise NotImplementedError
+
+    async def evaluate(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+def _make_env():
+    return _MinimalEnv.__new__(_MinimalEnv)
+
+
+def test_handle_env_missing_item_returns_none():
+    env = _make_env()
+    env.running_items = {}
+
+    result = asyncio.run(env.handle_env("does-not-exist"))
+
+    assert result is None
+
+
+def test_handle_env_present_item_is_processed():
+    env = _make_env()
+    sentinel = object()
+    env.running_items = {"uuid-1": {"item": sentinel}}
+    env.backlog = []
+    env.task_duration = []
+    env.task_successful = []
+    env.succeeded_task_duration = []
+    env.failed_task_duration = []
+
+    seen = {}
+
+    async def fake_collect_trajectories(item):
+        seen["item"] = item
+        return ["traj"], []
+
+    async def fake_postprocess_histories(trajectories):
+        return trajectories
+
+    async def fake_handle_send_to_api(to_postprocess, item):
+        seen["sent"] = to_postprocess
+
+    async def fake_cleanup():
+        return None
+
+    env.collect_trajectories = fake_collect_trajectories
+    env.postprocess_histories = fake_postprocess_histories
+    env.handle_send_to_api = fake_handle_send_to_api
+    env.cleanup = fake_cleanup
+
+    result = asyncio.run(env.handle_env("uuid-1"))
+
+    assert seen["item"] is sentinel
+    assert result == ["traj"]
+    assert "uuid-1" not in env.running_items


### PR DESCRIPTION

## PR Type
- [x] Non-Environment PR - Complete Description, Related Issues & Type of Change sections

---

## General Information

### Description

`BaseEnv.handle_env` starts by subscripting the result of a dict `.get()` before
checking whether it is `None`:

```python
item = self.running_items.get(item_uuid)["item"]
if item is None:
    logger.warning("item %s not found... returning", item_uuid)
    return None
```

When `item_uuid` is absent, `self.running_items.get(item_uuid)` returns `None` and
`None["item"]` raises `TypeError: 'NoneType' object is not subscriptable`. Because
the subscript runs first, the following `if item is None:` guard, plus its
`"item ... not found... returning"` warning, is unreachable dead code, even though
it shows the missing-key case was meant to be handled.

The key can legitimately be absent by the time the coroutine runs. `handle_env` is
scheduled with `asyncio.create_task(self.handle_env(item_uuid))` and the entry is
only written to `self.running_items` on the next lines, so the task can start
before the insert. Separately, `self.running_items` is reset or popped by several
concurrent paths before a scheduled `handle_env` first looks its uuid up:

- reset to a fresh dict on the STOP_TRAIN eval branch,
- reset to a fresh dict on the off-policy overflow branch,
- popped in the worker-reduction path,
- popped in the worker-timeout path.

Any of these can evict a uuid whose `handle_env` coroutine has not run yet, turning
what should be a clean "item not found, returning" into an unhandled `TypeError`
that crashes the worker task.

This looks the entry up once and guards it before subscripting, mirroring the safe
`self.running_items.pop(item_uuid, None)` already used later in the same method:

```python
entry = self.running_items.get(item_uuid)
if entry is None:
    logger.warning("item %s not found... returning", item_uuid)
    return None
item = entry["item"]
```

`is None` is the intended guard here: entries are always the
`{"item", "worker", "start_time"}` dict, so there is no falsy-but-valid entry to
worry about. The happy path is unchanged. A regression test covering the
missing-uuid path is added under `atroposlib/tests/`.

### Related Issues

None. Found while reading the rollout worker path; no existing issue tracks it.

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

---

## Developer & Reviewer Checklist
- [x] Code follows project style (black, isort, flake8 pass with pre-commit)
- [x] I have performed a self-review of my own code
- [x] New and existing unit tests pass locally with my changes
- [x] My changes generate no new warnings

---

## Verification (for the PR body / reviewer)

- New test alone:
  `pytest atroposlib/tests/test_handle_env_missing_item.py -v` -> 2 passed.
- Red -> green: reverting only the production hunk makes
  `test_handle_env_missing_item_returns_none` fail with exactly
  `TypeError: 'NoneType' object is not subscriptable` at `atroposlib/envs/base.py`;
  restoring the fix -> 2 passed.
- Full suite: `pytest -q` -> 152 passed, 50 skipped (the 50 skips are the
  GPU/vLLM-marked tests; matches the pre-change baseline of 150 + 2 new).
- `pre-commit run --files atroposlib/envs/base.py atroposlib/tests/test_handle_env_missing_item.py`
  -> all hooks pass (black, ruff, flake8 max-line 120, detect-secrets, codespell,
  trailing-whitespace, end-of-file).

Diff: 2 files, +79 / -2 (3-line logic change in `handle_env`, plus a new
76-line test file).

---

